### PR TITLE
Fix3/wiener5

### DIFF
--- a/stan/math/prim/functor/apply.hpp
+++ b/stan/math/prim/functor/apply.hpp
@@ -10,20 +10,23 @@ namespace math {
 namespace internal {
 /*
  * Invoke the functor f with arguments given in t and indexed in the index
- * sequence I
+ * sequence I with other arguments possibly before or after
  *
  * @tparam F Type of functor
  * @tparam Tuple Type of tuple containing arguments
+ * @tparam PreArgs Parameter pack of arguments before the tuple
  * @tparam I Parameter pack of an index sequence going from 0 to
  * std::tuple_size<T>::value - 1 inclusive
  * @param f functor callable
  * @param t tuple of arguments
  * @param i placeholder variable for index sequence
+ * @param pre_args parameter pack of arguments to place before elements in tuple.
  */
-template <class F, class Tuple, std::size_t... I>
+template <class F, class Tuple, typename... PreArgs, std::size_t... I>
 constexpr decltype(auto) apply_impl(F&& f, Tuple&& t,
-                                    std::index_sequence<I...> i) {
-  return f(std::forward<decltype(std::get<I>(t))>(std::get<I>(t))...);
+                                    std::index_sequence<I...> i,
+                                    PreArgs&&... pre_args) {
+  return std::forward<F>(f)(std::forward<PreArgs>(pre_args)..., std::forward<decltype(std::get<I>(t))>(std::get<I>(t))...);
 }
 }  // namespace internal
 
@@ -36,15 +39,18 @@ constexpr decltype(auto) apply_impl(F&& f, Tuple&& t,
  *
  * @tparam F Type of functor
  * @tparam Tuple Type of tuple containing arguments
+ * @tparam PreArgs Parameter pack of arguments before the tuple
  * @param f functor callable
  * @param t tuple of arguments
+ * @param pre_args parameter pack of arguments to place before elements in tuple.
  */
-template <class F, class Tuple>
-constexpr decltype(auto) apply(F&& f, Tuple&& t) {
+template <class F, class Tuple, typename... PreArgs>
+constexpr decltype(auto) apply(F&& f, Tuple&& t, PreArgs&&... pre_args) {
   return internal::apply_impl(
       std::forward<F>(f), std::forward<Tuple>(t),
       std::make_index_sequence<
-          std::tuple_size<std::remove_reference_t<Tuple>>{}>{});
+          std::tuple_size<std::remove_reference_t<Tuple>>{}>{},
+          std::forward<PreArgs>(pre_args)...);
 }
 
 }  // namespace math

--- a/stan/math/prim/meta/return_type.hpp
+++ b/stan/math/prim/meta/return_type.hpp
@@ -146,6 +146,26 @@ struct scalar_lub<std::complex<T1>, std::complex<T2>> {
 template <typename T1, typename T2>
 using scalar_lub_t = typename scalar_lub<T1, T2>::type;
 
+namespace internal {
+  template <typename... Ts>
+struct return_type_impl {
+  using type = double;
+};
+
+template <typename T, typename... Ts>
+struct return_type_impl<T, Ts...> {
+  using type
+      = scalar_lub_t<scalar_type_t<T>, typename return_type_impl<Ts...>::type>;
+};
+
+template <typename... T, typename... Ts>
+struct return_type_impl<std::tuple<T...>, Ts...> {
+  using type
+      = scalar_lub_t<typename return_type_impl<T...>::type, typename return_type_impl<Ts...>::type>;
+};
+
+}
+
 /**
  * Template metaprogram to calculate the base scalar return type
  * resulting from promoting all the scalar types of the template
@@ -184,15 +204,10 @@ using scalar_lub_t = typename scalar_lub<T1, T2>::type;
  * @ingroup type_trait
  */
 template <typename... Ts>
-struct return_type {
-  using type = double;
-};
+struct return_type : internal::return_type_impl<std::decay_t<Ts>...> {};
 
-template <typename T, typename... Ts>
-struct return_type<T, Ts...> {
-  using type
-      = scalar_lub_t<scalar_type_t<T>, typename return_type<Ts...>::type>;
-};
+
+
 
 /**
  * Convenience type for the return type of the specified template

--- a/stan/math/prim/prob.hpp
+++ b/stan/math/prim/prob.hpp
@@ -370,9 +370,9 @@
 #include <stan/math/prim/prob/weibull_lpdf.hpp>
 #include <stan/math/prim/prob/weibull_rng.hpp>
 #include <stan/math/prim/prob/wiener5_lpdf.hpp>
-#include <stan/math/prim/prob/wiener_full_lpdf.hpp>
-#include <stan/math/prim/prob/wiener_log.hpp>
 #include <stan/math/prim/prob/wiener_lpdf.hpp>
+#include <stan/math/prim/prob/wiener_log.hpp>
+#include <stan/math/prim/prob/wiener_full_lpdf.hpp>
 #include <stan/math/prim/prob/wishart_cholesky_lpdf.hpp>
 #include <stan/math/prim/prob/wishart_cholesky_rng.hpp>
 #include <stan/math/prim/prob/wishart_log.hpp>

--- a/stan/math/prim/prob/wiener5_lpdf.hpp
+++ b/stan/math/prim/prob/wiener5_lpdf.hpp
@@ -17,23 +17,19 @@ namespace internal {
  * @param sv The inter-trial variability of the drift rate
  * @return 'error_term' term
  */
-template <typename Scalar, typename T_y, typename T_a, typename T_v,
+template <typename T_y, typename T_a, typename T_v,
           typename T_w, typename T_sv>
-inline Scalar wiener5_compute_error_term(T_y&& y, T_a&& a, T_v&& v_value,
+inline auto wiener5_compute_error_term(T_y&& y, T_a&& a, T_v&& v_value,
                                          T_w&& w_value, T_sv&& sv) noexcept {
-  const Scalar w = 1.0 - w_value;
-  const Scalar v = -v_value;
-  const Scalar sv_sqr = square(sv);
-  const Scalar one_plus_svsqr_y = 1 + sv_sqr * y;
-  const Scalar two_avw = 2 * a * v * w;
-  const Scalar two_log_a = 2 * log(a);
-  if (sv != 0) {
-    return stan::math::eval((sv_sqr * square(a * w) - two_avw - square(v) * y)
-                                / 2.0 / one_plus_svsqr_y
-                            - two_log_a - 0.5 * log(one_plus_svsqr_y));
-  } else {
-    return stan::math::eval((-two_avw - square(v) * y) / 2.0 - two_log_a);
-  }
+  const auto w = 1.0 - w_value;
+  const auto v = -v_value;
+  const auto sv_sqr = square(sv);
+  const auto one_plus_svsqr_y = 1 + sv_sqr * y;
+  const auto two_avw = 2.0 * a * v * w;
+  const auto two_log_a = 2.0 * log(a);
+  return stan::math::eval((sv_sqr * square(a * w) - two_avw - square(v) * y)
+                              / 2.0 / one_plus_svsqr_y
+                          - two_log_a - 0.5 * log(one_plus_svsqr_y));
 }
 
 /**
@@ -50,36 +46,28 @@ inline Scalar wiener5_compute_error_term(T_y&& y, T_a&& a, T_v&& v_value,
  * @param sv The inter-trial variability of the drift rate
  * @return 'density_part_one' term
  */
-template <bool GradA, bool GradT, typename Scalar, typename T_y, typename T_a,
+template <bool GradA, bool GradT, typename T_y, typename T_a,
           typename T_v_value, typename T_w_value, typename T_sv>
-inline Scalar wiener5_density_part_one(T_y&& y, T_a&& a, T_v_value&& v_value,
+inline auto wiener5_density_part_one(T_y&& y, T_a&& a, T_v_value&& v_value,
                                        T_w_value&& w_value,
                                        T_sv&& sv) noexcept {
-  const Scalar w = 1.0 - w_value;
-  const Scalar v = -v_value;
-  const Scalar sv_sqr = square(sv);
-  const Scalar one_plus_svsqr_y = 1 + sv_sqr * y;
-  const Scalar two_avw = 2 * a * v * w;
-
-  const Scalar var_a = GradA ? w : a;
-  const Scalar var_b = GradA ? a : w;
-
+  const auto w = 1.0 - w_value;
+  const auto v = -v_value;
+  const auto sv_sqr = square(sv);
+  const auto one_plus_svsqr_y = 1 + sv_sqr * y;
   if (GradT) {
-    if (sv != 0) {
       return -0.5
-             * (square(sv_sqr) * (y + square(a * w)) + sv_sqr * (1 - two_avw)
+             * (square(sv_sqr) * (y + square(a * w)) + sv_sqr * (1 - (2.0 * a * v * w))
                 + square(v))
              / square(one_plus_svsqr_y);
+  } else {
+    if (GradA) {
+      return (-v * w + sv_sqr * square(w) * a) / one_plus_svsqr_y;
     } else {
-      return -0.5 * square(v);
+      return (-v * a + sv_sqr * square(a) * w) / one_plus_svsqr_y;
     }
   }
 
-  if (sv != 0) {
-    return (-v * var_a + sv_sqr * square(var_a) * var_b) / one_plus_svsqr_y;
-  } else {
-    return -v * var_a;
-  }
 }
 
 /**
@@ -136,39 +124,35 @@ inline Scalar wiener5_n_terms_small_t(T_y&& y, T_a&& a, T_w_value&& w_value,
  * @param error The error tolerance
  * @return 'n_terms_large_t' term
  */
-template <bool Density, bool GradW, typename Scalar, typename T_y, typename T_a,
-          typename T_w_value>
-inline Scalar wiener5_n_terms_large_t(T_y&& y, T_a&& a, T_w_value&& w_value,
-                                      Scalar error) noexcept {
-  const Scalar two_error = 2.0 * error;
-  const Scalar y_asq = y / square(a);
-  const Scalar two_log_a = 2 * log(a);
-  const Scalar log_y_asq = log(y) - two_log_a;
-  const Scalar w = 1.0 - w_value;
-
-  const Scalar n_1_factor = GradW ? 2 : 3;
+template <bool Density, bool GradW, typename T_y, typename T_a,
+          typename T_w_value, typename T_err>
+inline auto wiener5_n_terms_large_t(T_y&& y, T_a&& a, T_w_value&& w_value,
+                                      T_err error) noexcept {
+  const auto y_asq = y / square(a);
+  const auto log_y_asq = log(y) - 2 * log(a);
   static constexpr double PI_SQUARED = pi() * pi();
-
-  Scalar n_1;
-  Scalar n_2;
   if (Density) {
-    n_1 = 1.0 / (pi() * sqrt(y_asq));
-    const Scalar two_log_piy = -2.0 * (LOG_PI + log_y_asq + error);
-    n_2 = (two_log_piy >= 0) ? sqrt(two_log_piy / (PI_SQUARED * y_asq)) : 0.0;
+    auto n_1 = 1.0 / (pi() * sqrt(y_asq));
+    const auto two_log_piy = -2.0 * (LOG_PI + log_y_asq + error);
+    auto n_2 = (two_log_piy >= 0) ? sqrt(two_log_piy / (PI_SQUARED * y_asq)) : 0.0;
+    return ceil(fmax(n_1, n_2));
   } else {
-    n_1 = sqrt(n_1_factor / y_asq) / pi();
-    const Scalar u_eps_arg
+    const auto n_1_factor = GradW ? 2 : 3;
+    auto n_1 = sqrt(n_1_factor / y_asq) / pi();
+    const auto two_error = 2.0 * error;
+    const auto u_eps_arg
         = GradW
               ? log(4.0) - log(9.0) + 2.0 * LOG_PI + 3.0 * log_y_asq + two_error
               : log(3.0) - log(5.0) + LOG_PI + 2.0 * log_y_asq + error;
-    const Scalar u_eps = fmin(-1, u_eps_arg);
-    const Scalar arg_mult = GradW ? 1 : (2.0 / PI_SQUARED / y_asq);
-    const Scalar arg = -arg_mult * (u_eps - sqrt(-2.0 * u_eps - 2.0));
-    n_2 = GradW ? (arg > 0) ? sqrt(arg / y_asq) / pi() : n_1
-                : (arg > 0) ? sqrt(arg) : n_1;
+    const auto u_eps = fmin(-1, u_eps_arg);
+    const auto arg_mult = GradW ? 1 : (2.0 / PI_SQUARED / y_asq);
+    const auto arg = -arg_mult * (u_eps - sqrt(-2.0 * u_eps - 2.0));
+    auto n_2 = GradW ?
+      ((arg > 0) ? sqrt(arg / y_asq) / pi() : n_1)
+        : ((arg > 0) ? sqrt(arg) : n_1);
+    return ceil(fmax(n_1, n_2));
   }
 
-  return ceil(fmax(n_1, n_2));
 }
 
 /**
@@ -185,7 +169,7 @@ inline Scalar wiener5_n_terms_large_t(T_y&& y, T_a&& a, T_w_value&& w_value,
  * @param n_terms_large_t The n_terms_large_t term
  * @return 'result' sum and its sign
  */
-template <bool Density, bool GradW, typename Scalar, typename T_y, typename T_a,
+template <bool Density, bool GradW, typename T_y, typename T_a,
           typename T_w, typename T_nsmall, typename T_nlarge>
 inline auto wiener5_log_sum_exp(T_y&& y, T_a&& a, T_w&& w_value,
                                 T_nsmall&& n_terms_small_t,
@@ -196,20 +180,17 @@ inline auto wiener5_log_sum_exp(T_y&& y, T_a&& a, T_w&& w_value,
       = Density ? (2 * n_terms_small_t <= n_terms_large_t)
                 : (2 * n_terms_small_t < n_terms_large_t);
   const auto scaling = small_n_terms_small_t ? inv(2.0 * y_asq) : y_asq / 2.0;
-
-  using ret_t = return_type_t<T_y, T_a, T_w>;
-  ret_t current_val;
+  using ret_t = return_type_t<T_y, T_a, T_w, T_nsmall, T_nlarge>;
+  ret_t fplus = NEGATIVE_INFTY;
+  ret_t fminus = NEGATIVE_INFTY;
   int current_sign;
   if (small_n_terms_small_t) {
-    ret_t fplus = NEGATIVE_INFTY;
-    ret_t fminus = NEGATIVE_INFTY;
-    const auto mult = Density ? 1 : 3;
-    const auto offset = GradW ? y_asq : 0;
-
-    for (auto k = n_terms_small_t; k >= 1; k--) {
-      const auto wp2k = w + 2.0 * k;
-      const auto wm2k = w - 2.0 * k;
-      if (GradW) {
+    constexpr double mult = Density ? 1.0 : 3.0;
+    if (GradW) {
+      const auto offset = y_asq;
+      for (auto k = n_terms_small_t; k >= 1; k--) {
+        const auto wp2k = w + 2.0 * k;
+        const auto wm2k = w - 2.0 * k;
         const auto sqwp2k_mo = square(wp2k) - offset;
         if (sqwp2k_mo > 0) {
           const auto wp2k_quant = log(sqwp2k_mo) - square(wp2k) * scaling;
@@ -218,12 +199,6 @@ inline auto wiener5_log_sum_exp(T_y&& y, T_a&& a, T_w&& w_value,
           const auto wp2k_quant = log(-sqwp2k_mo) - square(wp2k) * scaling;
           fminus = log_sum_exp(fminus, wp2k_quant);
         }
-      } else {
-        const auto wp2k_quant = mult * log(wp2k) - square(wp2k) * scaling;
-        fplus = log_sum_exp(fplus, wp2k_quant);
-      }
-
-      if (GradW) {
         const auto sqwm2k_mo = square(wm2k) - offset;
         if (sqwm2k_mo > 0) {
           const auto wm2k_quant = log(sqwm2k_mo) - square(wm2k) * scaling;
@@ -232,21 +207,7 @@ inline auto wiener5_log_sum_exp(T_y&& y, T_a&& a, T_w&& w_value,
           const auto wm2k_quant = log(-sqwm2k_mo) - square(wm2k) * scaling;
           fminus = log_sum_exp(fminus, wm2k_quant);
         }
-      } else {
-        const auto wm2k_quant = mult * log(-wm2k) - square(wm2k) * scaling;
-        if (fminus <= NEGATIVE_INFTY) {
-          fminus = wm2k_quant;
-        } else if (wm2k_quant <= NEGATIVE_INFTY) {
-          fminus = fminus;
-        } else if (fminus > wm2k_quant) {
-          fminus = fminus + log1p(exp(wm2k_quant - fminus));
-        } else {
-          fminus = wm2k_quant + log1p(exp(fminus - wm2k_quant));
-        }
       }
-    }
-
-    if (GradW) {
       const auto sqw_mo = square(w) - offset;
       if (sqw_mo > 0) {
         const auto new_val = log(sqw_mo) - square(w) * scaling;
@@ -256,32 +217,27 @@ inline auto wiener5_log_sum_exp(T_y&& y, T_a&& a, T_w&& w_value,
         fminus = log_sum_exp(fminus, new_val);
       }
     } else {
+      for (auto k = n_terms_small_t; k >= 1; k--) {
+        const auto wp2k = w + 2.0 * k;
+        const auto wm2k = w - 2.0 * k;
+        const auto wp2k_quant = mult * log(wp2k) - square(wp2k) * scaling;
+        fplus = log_sum_exp(fplus, wp2k_quant);
+        const auto wm2k_quant = mult * log(-wm2k) - square(wm2k) * scaling;
+        if (fminus <= NEGATIVE_INFTY) {
+          fminus = wm2k_quant;
+        } else if (wm2k_quant <= NEGATIVE_INFTY) {
+          continue;
+        } else if (fminus > wm2k_quant) {
+          fminus = fminus + log1p(exp(wm2k_quant - fminus));
+        } else {
+          fminus = wm2k_quant + log1p(exp(fminus - wm2k_quant));
+        }
+      }
       const auto new_val = mult * log(w) - square(w) * scaling;
       fplus = log_sum_exp(fplus, new_val);
     }
-
-    if (fplus == NEGATIVE_INFTY) {
-      current_val = fminus;
-    } else if (fminus == NEGATIVE_INFTY) {
-      current_val = fplus;
-    } else if (fplus > fminus) {
-      current_val = log_diff_exp(fplus, fminus);
-    } else if (fplus < fminus) {
-      current_val = log_diff_exp(fminus, fplus);
-    } else {
-      current_val = NEGATIVE_INFTY;
-    }
-    current_sign = (fplus < fminus) ? -1 : 1;
-
   } else {  // for large t
-    auto mult = 3;
-    if (Density) {
-      mult = 1;
-    } else if (GradW) {
-      mult = 2;
-    }
-    ret_t fplus = NEGATIVE_INFTY;
-    ret_t fminus = NEGATIVE_INFTY;
+    constexpr double mult = (Density ? 1 : (GradW ? 2 : 3));
     for (auto k = n_terms_large_t; k >= 1; k--) {
       const auto pi_k = k * pi();
       const auto check = (GradW) ? cos(pi_k * w) : sin(pi_k * w);
@@ -293,20 +249,19 @@ inline auto wiener5_log_sum_exp(T_y&& y, T_a&& a, T_w&& w_value,
             fminus, mult * log(k) - square(pi_k) * scaling + log(-check));
       }
     }
-    if (fplus == NEGATIVE_INFTY) {
-      current_val = fminus;
-    } else if (fminus == NEGATIVE_INFTY) {
-      current_val = fplus;
-    } else if (fplus > fminus) {
-      current_val = log_diff_exp(fplus, fminus);
-    } else if (fplus < fminus) {
-      current_val = log_diff_exp(fminus, fplus);
-    } else {
-      current_val = NEGATIVE_INFTY;
-    }
-    current_sign = (fplus < fminus) ? -1 : 1;
   }
-  return std::make_pair(current_val, current_sign);
+  current_sign = (fplus < fminus) ? -1 : 1;
+  if (fplus == NEGATIVE_INFTY) {
+    return std::make_pair(fminus, current_sign);
+  } else if (fminus == NEGATIVE_INFTY) {
+    return std::make_pair(fplus, current_sign);
+  } else if (fplus > fminus) {
+    return std::make_pair(log_diff_exp(fplus, fminus), current_sign);
+  } else if (fplus < fminus) {
+    return std::make_pair(log_diff_exp(fminus, fplus), current_sign);
+  } else {
+    return std::make_pair(ret_t(NEGATIVE_INFTY), current_sign);
+  }
 }
 
 /**
@@ -323,28 +278,28 @@ inline auto wiener5_log_sum_exp(T_y&& y, T_a&& a, T_w&& w_value,
  * @param err The log error tolerance
  * @return density
  */
-template <bool NaturalScale = false, typename Scalar, typename T_y,
-          typename T_a, typename T_w, typename T_v, typename T_sv>
-inline Scalar wiener5_density(const T_y& y, const T_a& a, const T_v& v_value,
+template <bool NaturalScale = false, typename T_y,
+          typename T_a, typename T_w, typename T_v, typename T_sv, typename T_err>
+inline auto wiener5_density(const T_y& y, const T_a& a, const T_v& v_value,
                               const T_w& w_value, const T_sv& sv,
-                              Scalar err = log(1e-12)) noexcept {
-  const Scalar error_term
-      = wiener5_compute_error_term<Scalar>(y, a, v_value, w_value, sv);
-  const Scalar error = (err - error_term);
-  const Scalar n_terms_small_t
-      = wiener5_n_terms_small_t<true, false, Scalar>(y, a, w_value, error);
-  const Scalar n_terms_large_t
-      = wiener5_n_terms_large_t<true, false, Scalar>(y, a, w_value, error);
+                              T_err err = log(1e-12)) noexcept {
+  const auto error_term
+      = wiener5_compute_error_term(y, a, v_value, w_value, sv);
+  const auto error = (err - error_term);
+  const auto n_terms_small_t
+      = wiener5_n_terms_small_t<true, false>(y, a, w_value, error);
+  const auto n_terms_large_t
+      = wiener5_n_terms_large_t<true, false>(y, a, w_value, error);
 
-  auto res = wiener5_log_sum_exp<true, false, Scalar>(
+  auto res = wiener5_log_sum_exp<true, false>(
                  y, a, w_value, n_terms_small_t, n_terms_large_t)
                  .first;
   if (2 * n_terms_small_t <= n_terms_large_t) {
-    Scalar log_density = error_term - 0.5 * LOG_TWO - LOG_SQRT_PI
+    auto log_density = error_term - 0.5 * LOG_TWO - LOG_SQRT_PI
                          - 1.5 * (log(y) - 2 * log(a)) + res;
     return NaturalScale ? exp(log_density) : log_density;
   } else {
-    Scalar log_density = error_term + res + LOG_PI;
+    auto log_density = error_term + res + LOG_PI;
     return NaturalScale ? exp(log_density) : log_density;
   }
 }
@@ -364,46 +319,43 @@ inline Scalar wiener5_density(const T_y& y, const T_a& a, const T_v& v_value,
  * @param err The log error tolerance
  * @return Gradient w.r.t. t
  */
-template <bool WrtLog = false, typename Scalar, typename T_y, typename T_a,
-          typename T_w, typename T_v, typename T_sv>
-inline Scalar wiener5_grad_t(const T_y& y, const T_a& a, const T_v& v_value,
+template <bool WrtLog = false, typename T_y, typename T_a,
+          typename T_w, typename T_v, typename T_sv, typename T_err>
+inline auto wiener5_grad_t(const T_y& y, const T_a& a, const T_v& v_value,
                              const T_w& w_value, const T_sv& sv,
-                             Scalar err = log(1e-12)) noexcept {
-  const Scalar two_log_a = 2 * log(a);
-  const Scalar log_y_asq = log(y) - two_log_a;
-  const Scalar error_term
-      = wiener5_compute_error_term<Scalar>(y, a, v_value, w_value, sv);
-  const Scalar density_part_one = wiener5_density_part_one<false, true, Scalar>(
+                             T_err err = log(1e-12)) noexcept {
+  const auto two_log_a = 2 * log(a);
+  const auto log_y_asq = log(y) - two_log_a;
+  const auto error_term
+      = wiener5_compute_error_term(y, a, v_value, w_value, sv);
+  const auto density_part_one = wiener5_density_part_one<false, true>(
       y, a, v_value, w_value, sv);
-  const Scalar error = (err - error_term) + two_log_a;
-
-  const Scalar n_terms_small_t
-      = wiener5_n_terms_small_t<false, false, Scalar>(y, a, w_value, error);
-  const Scalar n_terms_large_t
-      = wiener5_n_terms_large_t<false, false, Scalar>(y, a, w_value, error);
-  Scalar result;
-  int newsign;
-  std::forward_as_tuple(result, newsign)
-      = wiener5_log_sum_exp<false, false, Scalar>(
+  const auto error = (err - error_term) + two_log_a;
+  const auto n_terms_small_t
+      = wiener5_n_terms_small_t<false, false>(y, a, w_value, error);
+  const auto n_terms_large_t
+      = wiener5_n_terms_large_t<false, false>(y, a, w_value, error);
+  auto wiener_res = wiener5_log_sum_exp<false, false>(
           y, a, w_value, n_terms_small_t, n_terms_large_t);
-
-  const Scalar error_log_density
+  auto&& result = wiener_res.first;
+  auto&& newsign = wiener_res.second;
+  const auto error_log_density
       = log(fmax(fabs(density_part_one - 1.5 / y), fabs(density_part_one)));
-  const Scalar log_density = wiener5_density<false, Scalar>(
+  const auto log_density = wiener5_density<false>(
       y, a, v_value, w_value, sv, err - error_log_density);
-  Scalar ans;
   if (2 * n_terms_small_t < n_terms_large_t) {
-    ans = density_part_one - 1.5 / y
+  auto ans = density_part_one - 1.5 / y
           + newsign
                 * exp(error_term - two_log_a - 1.5 * LOG_TWO - LOG_SQRT_PI
                       - 3.5 * log_y_asq + result - log_density);
-  } else {
-    ans = density_part_one
+  return WrtLog ? ans * exp(log_density) : ans;
+} else {
+  auto ans = density_part_one
           - newsign
                 * exp(error_term - two_log_a + 3.0 * LOG_PI - LOG_TWO + result
                       - log_density);
-  }
   return WrtLog ? ans * exp(log_density) : ans;
+  }
 }
 
 /**
@@ -421,46 +373,44 @@ inline Scalar wiener5_grad_t(const T_y& y, const T_a& a, const T_v& v_value,
  * @param err The log error tolerance
  * @return Gradient w.r.t. a
  */
-template <bool WrtLog = false, typename Scalar, typename T_y, typename T_a,
-          typename T_w, typename T_v, typename T_sv>
-inline Scalar wiener5_grad_a(const T_y& y, const T_a& a, const T_v& v_value,
+template <bool WrtLog = false, typename T_y, typename T_a,
+          typename T_w, typename T_v, typename T_sv, typename T_err>
+inline auto wiener5_grad_a(const T_y& y, const T_a& a, const T_v& v_value,
                              const T_w& w_value, const T_sv& sv,
-                             Scalar err = log(1e-12)) noexcept {
-  const Scalar two_log_a = 2 * log(a);
-  const Scalar log_y_asq = log(y) - two_log_a;
-  const Scalar error_term
-      = wiener5_compute_error_term<Scalar>(y, a, v_value, w_value, sv);
-  const Scalar density_part_one = wiener5_density_part_one<true, false, Scalar>(
+                             T_err err = log(1e-12)) noexcept {
+  const auto two_log_a = 2 * log(a);
+  const auto log_y_asq = log(y) - two_log_a;
+  const auto error_term
+      = wiener5_compute_error_term(y, a, v_value, w_value, sv);
+  const auto density_part_one = wiener5_density_part_one<true, false>(
       y, a, v_value, w_value, sv);
-  const Scalar error = err - error_term + 3 * log(a) - log(y) - LOG_TWO;
+  const auto error = err - error_term + 3 * log(a) - log(y) - LOG_TWO;
 
-  const Scalar n_terms_small_t
-      = wiener5_n_terms_small_t<false, false, Scalar>(y, a, w_value, error);
-  const Scalar n_terms_large_t
-      = wiener5_n_terms_large_t<false, false, Scalar>(y, a, w_value, error);
-  Scalar result;
-  int newsign;
-  std::forward_as_tuple(result, newsign)
-      = wiener5_log_sum_exp<false, false, Scalar>(
+  const auto n_terms_small_t
+      = wiener5_n_terms_small_t<false, false>(y, a, w_value, error);
+  const auto n_terms_large_t
+      = wiener5_n_terms_large_t<false, false>(y, a, w_value, error);
+  auto wiener_res = wiener5_log_sum_exp<false, false>(
           y, a, w_value, n_terms_small_t, n_terms_large_t);
-
-  const Scalar error_log_density = log(
+  auto&& result = wiener_res.first;
+  auto&& newsign = wiener_res.second;
+  const auto error_log_density = log(
       fmax(fabs(density_part_one + 1.0 / a), fabs(density_part_one - 2.0 / a)));
-  const Scalar log_density = wiener5_density<false, Scalar>(
+  const auto log_density = wiener5_density<false>(
       y, a, v_value, w_value, sv, err - error_log_density);
-  Scalar ans;
   if (2 * n_terms_small_t < n_terms_large_t) {
-    ans = density_part_one + 1.0 / a
+    auto ans = density_part_one + 1.0 / a
           - newsign
                 * exp(-0.5 * LOG_TWO - LOG_SQRT_PI - 2.5 * log(y)
                       + 2.0 * two_log_a + error_term + result - log_density);
+    return WrtLog ? ans * exp(log_density) : ans;
   } else {
-    ans = density_part_one - 2.0 / a
+    auto ans = density_part_one - 2.0 / a
           + newsign
                 * exp(log(y) + error_term - 3 * (log(a) - LOG_PI) + result
                       - log_density);
+    return WrtLog ? ans * exp(log_density) : ans;
   }
-  return WrtLog ? ans * exp(log_density) : ans;
 }
 
 /**
@@ -478,19 +428,17 @@ inline Scalar wiener5_grad_a(const T_y& y, const T_a& a, const T_v& v_value,
  * @param err The log error tolerance
  * @return Gradient w.r.t. v
  */
-template <bool WrtLog = false, typename Scalar, typename T_y, typename T_a,
-          typename T_w, typename T_v, typename T_sv>
-inline Scalar wiener5_grad_v(const T_y& y, const T_a& a, const T_v& v_value,
+template <bool WrtLog = false, typename T_y, typename T_a,
+          typename T_w, typename T_v, typename T_sv, typename T_err>
+inline auto wiener5_grad_v(const T_y& y, const T_a& a, const T_v& v_value,
                              const T_w& w_value, const T_sv& sv,
-                             Scalar err = log(1e-12)) noexcept {
-  Scalar ans = (a * (1 - w_value) - v_value * y);
-  if (sv != 0) {
-    ans /= 1 + square(sv) * y;
+                             T_err err = log(1e-12)) noexcept {
+  auto ans = (a * (1 - w_value) - v_value * y) / (1.0 + square(sv) * y);
+  if (WrtLog) {
+    return ans * wiener5_density<true>(y, a, v_value, w_value, sv, err);
+  } else {
+    return ans;
   }
-  return WrtLog ? ans
-                      * wiener5_density<true, Scalar>(y, a, v_value, w_value,
-                                                      sv, err)
-                : ans;
 }
 
 /**
@@ -508,43 +456,42 @@ inline Scalar wiener5_grad_v(const T_y& y, const T_a& a, const T_v& v_value,
  * @param err The log error tolerance
  * @return Gradient w.r.t. w
  */
-template <bool WrtLog = false, typename Scalar, typename T_y, typename T_a,
-          typename T_w, typename T_v, typename T_sv>
-inline Scalar wiener5_grad_w(const T_y& y, const T_a& a, const T_v& v_value,
+template <bool WrtLog = false, typename T_y, typename T_a,
+          typename T_w, typename T_v, typename T_sv, typename T_err>
+inline auto wiener5_grad_w(const T_y& y, const T_a& a, const T_v& v_value,
                              const T_w& w_value, const T_sv& sv,
-                             Scalar err = log(1e-12)) noexcept {
-  const Scalar two_log_a = 2 * log(a);
-  const Scalar log_y_asq = log(y) - two_log_a;
-  const Scalar error_term
-      = wiener5_compute_error_term<Scalar>(y, a, v_value, w_value, sv);
-  const Scalar density_part_one
-      = wiener5_density_part_one<false, false, Scalar>(y, a, v_value, w_value,
+                             T_err err = log(1e-12)) noexcept {
+  const auto two_log_a = 2 * log(a);
+  const auto log_y_asq = log(y) - two_log_a;
+  const auto error_term
+      = wiener5_compute_error_term(y, a, v_value, w_value, sv);
+  const auto density_part_one
+      = wiener5_density_part_one<false, false>(y, a, v_value, w_value,
                                                        sv);
-  const Scalar error = (err - error_term);
+  const auto error = (err - error_term);
 
-  const Scalar n_terms_small_t
-      = wiener5_n_terms_small_t<false, true, Scalar>(y, a, w_value, error);
-  const Scalar n_terms_large_t
-      = wiener5_n_terms_large_t<false, true, Scalar>(y, a, w_value, error);
-  Scalar result;
-  int newsign;
-  std::forward_as_tuple(result, newsign)
-      = wiener5_log_sum_exp<false, true, Scalar>(y, a, w_value, n_terms_small_t,
+  const auto n_terms_small_t
+      = wiener5_n_terms_small_t<false, true>(y, a, w_value, error);
+  const auto n_terms_large_t
+      = wiener5_n_terms_large_t<false, true>(y, a, w_value, error);
+  auto wiener_res
+      = wiener5_log_sum_exp<false, true>(y, a, w_value, n_terms_small_t,
                                                  n_terms_large_t);
-
-  const Scalar log_density = wiener5_density<false, Scalar>(
+  auto&& result = wiener_res.first;
+  auto&& newsign = wiener_res.second;
+  const auto log_density = wiener5_density<false>(
       y, a, v_value, w_value, sv, err - log(fabs(density_part_one)));
-  Scalar ans;
   if (2 * n_terms_small_t < n_terms_large_t) {
-    ans = -(density_part_one
+    auto ans = -(density_part_one
             - newsign
                   * exp(result - (log_density - error_term) - 2.5 * log_y_asq
                         - 0.5 * LOG_TWO - 0.5 * LOG_PI));
+    return WrtLog ? ans * exp(log_density) : ans;
   } else {
-    ans = -(density_part_one
+    auto ans = -(density_part_one
             + newsign * exp(result - (log_density - error_term) + 2 * LOG_PI));
+    return WrtLog ? ans * exp(log_density) : ans;
   }
-  return WrtLog ? ans * exp(log_density) : ans;
 }
 
 /**
@@ -562,20 +509,20 @@ inline Scalar wiener5_grad_w(const T_y& y, const T_a& a, const T_v& v_value,
  * @param err The log error tolerance
  * @return Gradient w.r.t. sv
  */
-template <bool WrtLog = false, typename Scalar, typename T_y, typename T_a,
-          typename T_w, typename T_v, typename T_sv>
-inline Scalar wiener5_grad_sv(const T_y& y, const T_a& a, const T_v& v_value,
+template <bool WrtLog = false, typename T_y, typename T_a,
+          typename T_w, typename T_v, typename T_sv, typename T_err>
+inline auto wiener5_grad_sv(const T_y& y, const T_a& a, const T_v& v_value,
                               const T_w& w_value, const T_sv& sv,
-                              Scalar err = log(1e-12)) noexcept {
-  const Scalar one_plus_svsqr_y = 1 + square(sv) * y;
-  const Scalar w = 1.0 - w_value;
-  const Scalar v = -v_value;
-  const Scalar t1 = -y / one_plus_svsqr_y;
-  const Scalar t2 = (square(a * w) + 2 * a * v * w * y + square(v * y))
+                              T_err err = log(1e-12)) noexcept {
+  const auto one_plus_svsqr_y = 1 + square(sv) * y;
+  const auto w = 1.0 - w_value;
+  const auto v = -v_value;
+  const auto t1 = -y / one_plus_svsqr_y;
+  const auto t2 = (square(a * w) + 2 * a * v * w * y + square(v * y))
                     / square(one_plus_svsqr_y);
-  const Scalar ans = sv * (t1 + t2);
+  const auto ans = sv * (t1 + t2);
   return WrtLog ? ans
-                      * wiener5_density<true, Scalar>(y, a, v_value, w_value,
+                      * wiener5_density<true>(y, a, v_value, w_value,
                                                       sv, err)
                 : ans;
 }
@@ -583,8 +530,8 @@ inline Scalar wiener5_grad_sv(const T_y& y, const T_a& a, const T_v& v_value,
 /**
  * Utility function for replacing a value with a specified error value
  */
-template <size_t NestedIndex, typename Scalar>
-inline void assign_err(Scalar arg, Scalar err) {
+template <size_t NestedIndex, typename Scalar1, typename Scalar2>
+inline void assign_err(Scalar1 arg, Scalar2 err) {
   arg = err;
 }
 
@@ -613,17 +560,17 @@ inline void assign_err(std::tuple<TArgs...>& args_tuple, Scalar err) {
  * @param args_tuple Tuple of arguments to pass to functor
  * @param log_result Whether the function result is already on the log-scale
  */
-template <typename Scalar, size_t ErrIndex, bool GradW7 = false,
-          size_t NestedIndex = 0, bool LogResult = true, typename F,
+template <size_t ErrIndex, bool GradW7 = false,
+          size_t NestedIndex = 0, bool LogResult = true, typename F, typename T_err,
           typename... ArgsTupleT>
-Scalar estimate_with_err_check(const F& functor, Scalar err,
+inline auto estimate_with_err_check(const F& functor, T_err err,
                                ArgsTupleT&&... args_tuple) {
-  Scalar result = functor(args_tuple...);
-  Scalar log_fabs_result = LogResult ? log(fabs(result)) : fabs(result);
+  auto result = functor(args_tuple...);
+  auto log_fabs_result = LogResult ? log(fabs(result)) : fabs(result);
   if (log_fabs_result < err) {
     log_fabs_result = is_inf(log_fabs_result) ? 0 : log_fabs_result;
     auto err_args_tuple = std::make_tuple(args_tuple...);
-    const Scalar new_error
+    const auto new_error
         = GradW7 ? err + log_fabs_result + LOG_TWO : err + log_fabs_result;
     assign_err<NestedIndex>(std::get<ErrIndex>(err_args_tuple), new_error);
     result = math::apply([&](auto&&... args) { return functor(args...); },
@@ -656,14 +603,14 @@ Scalar estimate_with_err_check(const F& functor, Scalar err,
  */
 template <bool propto = false, typename T_y, typename T_a, typename T_t0,
           typename T_w, typename T_v, typename T_sv,
-          typename ReturnT = return_type_t<T_y, T_a, T_t0, T_w, T_v, T_sv>>
-inline return_type_t<T_y, T_a, T_t0, T_w, T_v, T_sv> wiener5_lpdf(
+          typename T_precision>
+inline auto wiener5_lpdf(
     const T_y& y, const T_a& a, const T_t0& t0, const T_w& w, const T_v& v,
-    const T_sv& sv, const ReturnT& precision_derivatives) {
+    const T_sv& sv, const T_precision& precision_derivatives) {
   using T_partials_return = partials_return_t<T_y, T_a, T_t0, T_w, T_v, T_sv>;
-
+  using ret_t = return_type_t<T_y, T_a, T_t0, T_w, T_v, T_sv>;
   if (!include_summand<propto, T_y, T_a, T_t0, T_w, T_v, T_sv>::value) {
-    return 0;
+    return ret_t(0.0);
   }
 
   using T_y_ref = ref_type_if_t<!is_constant<T_y>::value, T_y>;
@@ -705,11 +652,11 @@ inline return_type_t<T_y, T_a, T_t0, T_w, T_v, T_sv> wiener5_lpdf(
   check_finite(function_name, "Inter-trial variability in drift rate", sv_val);
 
   if (size_zero(y, a, t0, w, v, sv)) {
-    return 0;
+    return ret_t(0.0);
   }
   const size_t N = max_size(y, a, t0, w, v, sv);
   if (!N) {
-    return 0;
+    return ret_t(0.0);
   }
 
   scalar_seq_view<T_y_ref> y_vec(y_ref);
@@ -730,9 +677,10 @@ inline return_type_t<T_y, T_a, T_t0, T_w, T_v, T_sv> wiener5_lpdf(
     }
   }
 
-  const T_partials_return log_error_density = log(1e-6);
-  const T_partials_return log_error_derivative = log(precision_derivatives);
-  const T_partials_return log_error_absolute = log(1e-12);
+  const auto log_error_density = log(1e-6);
+  const auto log_error_derivative = log(precision_derivatives);
+  const double log_error_absolute_val = log(1e-12);
+  const T_partials_return log_error_absolute = log_error_absolute_val;
   T_partials_return log_density = 0.0;
   auto ops_partials
       = make_partials_propagator(y_ref, a_ref, t0_ref, w_ref, v_ref, sv_ref);
@@ -745,32 +693,30 @@ inline return_type_t<T_y, T_a, T_t0, T_w, T_v, T_sv> wiener5_lpdf(
     // sv_vec[i] == 0) or 5-parameter model with inter-trial variability in
     // drift rate (if sv_vec[i] != 0)
 
-    const T_partials_return y_value = y_vec.val(i);
-    const T_partials_return a_value = a_vec.val(i);
-    const T_partials_return t0_value = t0_vec.val(i);
-    const T_partials_return w_value = w_vec.val(i);
-    const T_partials_return v_value = v_vec.val(i);
-    const T_partials_return sv_value = sv_vec.val(i);
+    const auto y_value = y_vec.val(i);
+    const auto a_value = a_vec.val(i);
+    const auto t0_value = t0_vec.val(i);
+    const auto w_value = w_vec.val(i);
+    const auto v_value = v_vec.val(i);
+    const auto sv_value = sv_vec.val(i);
 
-    T_partials_return l_density = internal::estimate_with_err_check<
-        T_partials_return, 5, false, 0, false>(
+    auto l_density = internal::estimate_with_err_check<5, false, 0, false>(
         [&](auto&&... args) {
-          return internal::wiener5_density<false, T_partials_return>(args...);
+          return internal::wiener5_density<false>(args...);
         },
         log_error_density - LOG_TWO, y_value - t0_value, a_value, v_value,
         w_value, sv_value, log_error_absolute);
 
     log_density += l_density;
 
-    const T_partials_return new_est_err
+    const auto new_est_err
         = l_density + log_error_derivative - LOG_FOUR;
 
     // computation of derivative for t and precision check in order to give
     // the value as deriv_y to edge1 and as -deriv_y to edge5
-    const T_partials_return deriv_y = internal::estimate_with_err_check<
-        T_partials_return, 5, false, 0, true>(
+    const auto deriv_y = internal::estimate_with_err_check<5, false, 0, true>(
         [&](auto&&... args) {
-          return internal::wiener5_grad_t<false, T_partials_return>(args...);
+          return internal::wiener5_grad_t<false>(args...);
         },
         new_est_err, y_value - t0_value, a_value, v_value, w_value, sv_value,
         log_error_absolute);
@@ -780,10 +726,9 @@ inline return_type_t<T_y, T_a, T_t0, T_w, T_v, T_sv> wiener5_lpdf(
       partials<0>(ops_partials)[i] = deriv_y;
     }
     if (!is_constant_all<T_a>::value) {
-      partials<1>(ops_partials)[i] = internal::estimate_with_err_check<
-          T_partials_return, 5, false, 0, true>(
+      partials<1>(ops_partials)[i] = internal::estimate_with_err_check<5, false, 0, true>(
           [&](auto&&... args) {
-            return internal::wiener5_grad_a<false, T_partials_return>(args...);
+            return internal::wiener5_grad_a<false>(args...);
           },
           new_est_err, y_value - t0_value, a_value, v_value, w_value, sv_value,
           log_error_absolute);
@@ -792,23 +737,22 @@ inline return_type_t<T_y, T_a, T_t0, T_w, T_v, T_sv> wiener5_lpdf(
       partials<2>(ops_partials)[i] = -deriv_y;
     }
     if (!is_constant_all<T_w>::value) {
-      partials<3>(ops_partials)[i] = internal::estimate_with_err_check<
-          T_partials_return, 5, false, 0, true>(
+      partials<3>(ops_partials)[i] = internal::estimate_with_err_check<5, false, 0, true>(
           [&](auto&&... args) {
-            return internal::wiener5_grad_w<false, T_partials_return>(args...);
+            return internal::wiener5_grad_w<false>(args...);
           },
           new_est_err, y_value - t0_value, a_value, v_value, w_value, sv_value,
           log_error_absolute);
     }
     if (!is_constant_all<T_v>::value) {
       partials<4>(ops_partials)[i]
-          = internal::wiener5_grad_v<false, T_partials_return>(
-              y_value - t0_value, a_value, v_value, w_value, sv_value);
+          = internal::wiener5_grad_v<false>(
+              y_value - t0_value, a_value, v_value, w_value, sv_value, log_error_absolute_val);
     }
     if (!is_constant_all<T_sv>::value) {
       partials<5>(ops_partials)[i]
-          = internal::wiener5_grad_sv<false, T_partials_return>(
-              y_value - t0_value, a_value, v_value, w_value, sv_value);
+          = internal::wiener5_grad_sv<false>(
+              y_value - t0_value, a_value, v_value, w_value, sv_value, log_error_absolute_val);
     }
   }  // end for loop
   return ops_partials.build(log_density);

--- a/stan/math/prim/prob/wiener_full_lpdf.hpp
+++ b/stan/math/prim/prob/wiener_full_lpdf.hpp
@@ -21,20 +21,19 @@ namespace internal {
  * @param log_error The log error tolerance
  * @return Gradient w.r.t. sw
  */
-template <typename T_y, typename T_a, typename T_v,
-          typename T_w, typename T_sv, typename T_sw, typename T_err>
+template <typename T_y, typename T_a, typename T_v, typename T_w, typename T_sv,
+          typename T_sw, typename T_err>
 inline auto wiener7_grad_sw(const T_y& y, const T_a& a, const T_v& v,
-                               const T_w& w, const T_sv& sv, const T_sw& sw,
-                               T_err log_error) {
+                            const T_w& w, const T_sv& sv, const T_sw& sw,
+                            T_err log_error) {
   auto low = w - sw / 2.0;
   low = (0 > low) ? 0 : low;
+  const auto lower_value
+      = wiener5_density<GradientCalc::ON>(y, a, v, low, sv, log_error);
   auto high = w + sw / 2.0;
   high = (1 < high) ? 1 : high;
-
-  const auto lower_value
-      = wiener5_density<true>(y, a, v, low, sv, log_error);
   const auto upper_value
-      = wiener5_density<true>(y, a, v, high, sv, log_error);
+      = wiener5_density<GradientCalc::ON>(y, a, v, high, sv, log_error);
   return 0.5 * (lower_value + upper_value) / sw;
 }
 
@@ -61,11 +60,12 @@ inline auto wiener7_grad_sw(const T_y& y, const T_a& a, const T_v& v,
  * @param log_error The log error tolerance
  * @return Functor applied to arguments
  */
-template <typename Scalar, bool GradSW, typename F,
+template <bool GradSW, typename F, typename T_y, typename T_a, typename T_v,
+          typename T_w, typename T_sv, typename T_sw, typename T_err,
           std::enable_if_t<!GradSW>* = nullptr>
-inline Scalar conditionally_grad_sw(const F& functor, Scalar y_diff, Scalar a,
-                                    Scalar v, Scalar w, Scalar sv, Scalar sw,
-                                    Scalar log_error) {
+inline auto conditionally_grad_sw(F&& functor, T_y&& y_diff, T_a&& a, T_v&& v,
+                                  T_w&& w, T_sv&& sv, T_sw&& sw,
+                                  T_err&& log_error) {
   return functor(y_diff, a, v, w, sv, log_error);
 }
 
@@ -93,11 +93,12 @@ inline Scalar conditionally_grad_sw(const F& functor, Scalar y_diff, Scalar a,
  * @param log_error The log error tolerance
  * @return Functor applied to arguments
  */
-template <typename Scalar, bool GradSW, typename F,
+template <bool GradSW, typename F, typename T_y, typename T_a, typename T_v,
+          typename T_w, typename T_sv, typename T_sw, typename T_err,
           std::enable_if_t<GradSW>* = nullptr>
-inline Scalar conditionally_grad_sw(const F& functor, Scalar y_diff, Scalar a,
-                                    Scalar v, Scalar w, Scalar sv, Scalar sw,
-                                    Scalar log_error) {
+inline auto conditionally_grad_sw(F&& functor, T_y&& y_diff, T_a&& a, T_v&& v,
+                                  T_w&& w, T_sv&& sv, T_sw&& sw,
+                                  T_err&& log_error) {
   return functor(y_diff, a, v, w, sv, sw, log_error);
 }
 
@@ -116,31 +117,35 @@ inline Scalar conditionally_grad_sw(const F& functor, Scalar y_diff, Scalar a,
  * @param args Additional arguments to be passed to the hcubature function
  * @return Wiener7 density or gradient calculated by integration
  */
-template <typename Scalar, bool GradSW, bool GradW7 = false,
-          typename Wiener7FunctorT, typename... TArgs,
-          typename ReturnT = return_type_t<Scalar>>
-ReturnT wiener7_integrate(const Wiener7FunctorT& wiener7_functor,
-                          Scalar hcubature_err, TArgs&&... args) {
+template <bool GradSW, GradientCalc GradW7 = GradientCalc::OFF,
+          typename Wiener7FunctorT, typename T_err, typename... TArgs>
+inline auto wiener7_integrate(const Wiener7FunctorT& wiener7_functor,
+                              T_err&& hcubature_err, TArgs&&... args) {
   const auto wiener7_integrand_impl =
-      [&](auto&& x, Scalar y, Scalar a, Scalar v, Scalar w, Scalar t0,
-          Scalar sv, Scalar sw, Scalar st0, Scalar log_error) {
+      [&wiener7_functor](auto&& x, auto&& y, auto&& a, auto&& v, auto&& w,
+                         auto&& t0, auto&& sv, auto&& sw, auto&& st0,
+                         auto&& log_error) {
+        using ret_t
+            = return_type_t<decltype(x), decltype(a), decltype(v), decltype(w),
+                            decltype(t0), decltype(sv), decltype(sw),
+                            decltype(st0), decltype(st0), decltype(log_error)>;
         scalar_seq_view<decltype(x)> x_vec(x);
-        const Scalar sw_val = GradSW ? 0 : sw;
-        const Scalar new_w = (sw_val != 0) ? w + sw_val * (x_vec[0] - 0.5) : w;
-        const Scalar new_t0 = (sw_val != 0)
-                                  ? ((st0 != 0) ? t0 + st0 * x_vec[1] : t0)
-                                  : ((st0 != 0) ? t0 + st0 * x_vec[0] : t0);
+        const auto sw_val = GradSW ? 0 : sw;
+        const auto new_w = w + sw_val * (x_vec[0] - 0.5);
+        const auto new_t0 = (sw_val != 0)
+                                ? ((st0 != 0) ? t0 + st0 * x_vec[1] : t0)
+                                : ((st0 != 0) ? t0 + st0 * x_vec[0] : t0);
         if (y - new_t0 <= 0) {
-          return static_cast<Scalar>(0.0);
+          return ret_t(0.0);
         } else {
-          return conditionally_grad_sw<Scalar, GradSW>(
-              wiener7_functor, y - new_t0, a, v, new_w, sv, sw, log_error);
+          return ret_t(conditionally_grad_sw<GradSW>(
+              wiener7_functor, y - new_t0, a, v, new_w, sv, sw, log_error));
         }
       };
-  const auto functor = [&](auto&&... int_args) {
+  const auto functor = [&wiener7_integrand_impl](auto&&... int_args) {
     return hcubature(wiener7_integrand_impl, int_args...);
   };
-  return estimate_with_err_check<0, GradW7, 8, true>(
+  return estimate_with_err_check<0, GradW7, 8, GradientCalc::ON>(
       functor, hcubature_err, args...);
 }
 }  // namespace internal
@@ -191,7 +196,7 @@ ReturnT wiener7_integrate(const Wiener7FunctorT& wiener7_functor,
  * \c t0 is the lower bound of the variability interval;
  * \c w is the mean of the variability interval.
  *
- * See \b Details below for more details on how to use \c wiener_full_lpdf().
+ * See \b Details below for more details on how to use \c wiener_lpdf().
  *
  * @tparam T_y type of scalar
  * @tparam T_a type of boundary separation
@@ -225,14 +230,14 @@ ReturnT wiener7_integrate(const Wiener7FunctorT& wiener7_functor,
  *
  * The function can be called by
  @code
- target += wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+ target += wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
  @endcode
  * or
  @code
  y ~ wiener_full(a, t0, w, v, sv, sw, st0);
  @endcode
  *
- * By default \c wiener_full_lpdf() gives the log of the
+ * By default \c wiener_lpdf() gives the log of the
  * Wiener first-passage time probability density function for the \e upper
  response
  * boundary. To use the \e lower response boundary \c v and \c w must be changed
@@ -247,21 +252,21 @@ ReturnT wiener7_integrate(const Wiener7FunctorT& wiener7_functor,
  * variability for the relative starting point is needed one can write something
  like:
  @code
- target += wiener_full_lpdf(y, a, t0, w, v, sv, 0, st0)
+ target += wiener_lpdf(y, a, t0, w, v, sv, 0, st0)
  @endcode
  * If no inter-trial variability is needed at all one can write something like:
  @code
- target += wiener_full_lpdf(y, a, t0, w, v, 0, 0, 0)
+ target += wiener_lpdf(y, a, t0, w, v, 0, 0, 0)
  @endcode
  * If for some reason no non-decision time is assumed one can write something
  like:
  @code
- target += wiener_full_lpdf(y, a, 0, w, v, sv, sw, 0)
+ target += wiener_lpdf(y, a, 0, w, v, sv, sw, 0)
  @endcode
  *
  * To also control the precision in the estimation of the partial derivatives:
  @code
- target += wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0, precision);
+ target += wiener_lpdf(y, a, t0, w, v, sv, sw, st0, precision);
  @endcode
  *
  *
@@ -293,10 +298,10 @@ ReturnT wiener7_integrate(const Wiener7FunctorT& wiener7_functor,
 template <bool propto = false, typename T_y, typename T_a, typename T_t0,
           typename T_w, typename T_v, typename T_sv, typename T_sw,
           typename T_st0>
-inline auto wiener_full_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
-                                const T_w& w, const T_v& v, const T_sv& sv,
-                                const T_sw& sw, const T_st0& st0,
-                                const double& precision_derivatives = 1e-4) {
+inline auto wiener_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
+                        const T_w& w, const T_v& v, const T_sv& sv,
+                        const T_sw& sw, const T_st0& st0,
+                        const double& precision_derivatives = 1e-4) {
   using ret_t = return_type_t<T_y, T_a, T_t0, T_w, T_v, T_sv, T_sw, T_st0>;
   if (!include_summand<propto, T_y, T_a, T_v, T_w, T_t0, T_sv, T_sw,
                        T_st0>::value) {
@@ -315,7 +320,7 @@ inline auto wiener_full_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
   using T_partials_return
       = partials_return_t<T_y, T_a, T_t0, T_w, T_v, T_sv, T_sw, T_st0>;
 
-  static constexpr const char* function_name = "wiener_full_lpdf";
+  static constexpr const char* function_name = "wiener_lpdf";
   check_consistent_sizes(function_name, "Random variable", y,
                          "Boundary separation", a, "Drift rate", v,
                          "A-priori bias", w, "Nondecision time", t0,
@@ -386,26 +391,31 @@ inline auto wiener_full_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
   size_t N_beta_sw = max_size(w, sw);
   for (size_t i = 0; i < N_beta_sw; ++i) {
     if (unlikely(w_vec[i] - .5 * sw_vec[i] <= 0)) {
-      std::stringstream msg;
-      msg << ", but must be smaller than 2*(A-priori bias) = " << 2 * w_vec[i];
-      std::string msg_str(msg.str());
-      throw_domain_error(function_name,
-                         "Inter-trial variability in A-priori bias", sw_vec[i],
-                         " = ", msg_str.c_str());
+      [&]() STAN_COLD_PATH {
+        std::stringstream msg;
+        msg << ", but must be smaller than 2*(A-priori bias) = "
+            << 2 * w_vec[i];
+        std::string msg_str(msg.str());
+        throw_domain_error(function_name,
+                           "Inter-trial variability in A-priori bias",
+                           sw_vec[i], " = ", msg_str.c_str());
+      }();
     }
     if (unlikely(w_vec[i] + .5 * sw_vec[i] >= 1)) {
-      std::stringstream msg;
-      msg << ", but must be smaller than 2*(1-A-priori bias) = "
-          << 2 * (1 - w_vec[i]);
-      std::string msg_str(msg.str());
-      throw_domain_error(function_name,
-                         "Inter-trial variability in A-priori bias", sw_vec[i],
-                         " = ", msg_str.c_str());
+      [&]() STAN_COLD_PATH {
+        std::stringstream msg;
+        msg << ", but must be smaller than 2*(1-A-priori bias) = "
+            << 2 * (1 - w_vec[i]);
+        std::string msg_str(msg.str());
+        throw_domain_error(function_name,
+                           "Inter-trial variability in A-priori bias",
+                           sw_vec[i], " = ", msg_str.c_str());
+      }();
     }
   }
 
   const T_partials_return log_error_density
-      = log(1e-6);  // precision for density
+      = log(1e-6);                                 // precision for density
   const auto error_bound = precision_derivatives;  // precision for
   // derivatives (controllable by user)
   const auto log_error_derivative = log(error_bound);
@@ -422,8 +432,8 @@ inline auto wiener_full_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
   // calculate density and partials
   for (size_t i = 0; i < N; i++) {
     if (sw_vec[i] == 0 && st0_vec[i] == 0) {
-      result += wiener5_lpdf<propto>(y_vec[i], a_vec[i], t0_vec[i], w_vec[i],
-                                   v_vec[i], sv_vec[i], precision_derivatives);
+      result += wiener_lpdf<propto>(y_vec[i], a_vec[i], t0_vec[i], w_vec[i],
+                                    v_vec[i], sv_vec[i], precision_derivatives);
       continue;
     }
     const T_partials_return y_value = y_vec.val(i);
@@ -448,14 +458,14 @@ inline auto wiener_full_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
 
     T_partials_return hcubature_err
         = log_error_absolute - log_error_density + LOG_TWO + 1;
+    using internal::GradientCalc;
     const auto params = std::make_tuple(y_value, a_value, v_value, w_value,
                                         t0_value, sv_value, sw_value, st0_value,
                                         log_error_absolute - LOG_TWO);
     T_partials_return density
-        = internal::wiener7_integrate<T_partials_return, false, false>(
-            [&](auto&&... args) {
-              return internal::wiener5_density<true>(
-                  args...);
+        = internal::wiener7_integrate<GradientCalc::OFF, GradientCalc::OFF>(
+            [](auto&&... args) {
+              return internal::wiener5_density<GradientCalc::ON>(args...);
             },
             hcubature_err, params, dim, xmin, xmax,
             maximal_evaluations_hcubature, absolute_error_hcubature,
@@ -468,9 +478,9 @@ inline auto wiener_full_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
     // computation of derivative for t and precision check in order to give
     // the value as deriv_t to edge1 and as -deriv_t to edge5
     const T_partials_return deriv_t_7
-        = internal::wiener7_integrate<T_partials_return, false, false>(
-              [&](auto&&... args) {
-                return internal::wiener5_grad_t<true>(args...);
+        = internal::wiener7_integrate<GradientCalc::OFF, GradientCalc::OFF>(
+              [](auto&&... args) {
+                return internal::wiener5_grad_t<GradientCalc::ON>(args...);
               },
               hcubature_err, params, dim, xmin, xmax,
               maximal_evaluations_hcubature, absolute_error_hcubature,
@@ -484,9 +494,9 @@ inline auto wiener_full_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
     }
     if (!is_constant_all<T_a>::value) {
       partials<1>(ops_partials)[i]
-          = internal::wiener7_integrate<T_partials_return, false, false>(
-                [&](auto&&... args) {
-                  return internal::wiener5_grad_a<true>(args...);
+          = internal::wiener7_integrate<GradientCalc::OFF, GradientCalc::OFF>(
+                [](auto&&... args) {
+                  return internal::wiener5_grad_a<GradientCalc::ON>(args...);
                 },
                 hcubature_err, params, dim, xmin, xmax,
                 maximal_evaluations_hcubature, absolute_error_hcubature,
@@ -498,9 +508,9 @@ inline auto wiener_full_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
     }
     if (!is_constant_all<T_w>::value) {
       partials<3>(ops_partials)[i]
-          = internal::wiener7_integrate<T_partials_return, false, true>(
-                [&](auto&&... args) {
-                  return internal::wiener5_grad_w<true>(args...);
+          = internal::wiener7_integrate<GradientCalc::OFF, GradientCalc::ON>(
+                [](auto&&... args) {
+                  return internal::wiener5_grad_w<GradientCalc::ON>(args...);
                 },
                 hcubature_err, params, dim, xmin, xmax,
                 maximal_evaluations_hcubature, absolute_error_hcubature,
@@ -509,9 +519,9 @@ inline auto wiener_full_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
     }
     if (!is_constant_all<T_v>::value) {
       partials<4>(ops_partials)[i]
-          = internal::wiener7_integrate<T_partials_return, false, false>(
-                [&](auto&&... args) {
-                  return internal::wiener5_grad_v<true>(args...);
+          = internal::wiener7_integrate<GradientCalc::OFF, GradientCalc::OFF>(
+                [](auto&&... args) {
+                  return internal::wiener5_grad_v<GradientCalc::ON>(args...);
                 },
                 hcubature_err, params, dim, xmin, xmax,
                 maximal_evaluations_hcubature, absolute_error_hcubature,
@@ -520,9 +530,9 @@ inline auto wiener_full_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
     }
     if (!is_constant_all<T_sv>::value) {
       partials<5>(ops_partials)[i]
-          = internal::wiener7_integrate<T_partials_return, false, false>(
-                [&](auto&&... args) {
-                  return internal::wiener5_grad_sv<true>(args...);
+          = internal::wiener7_integrate<GradientCalc::OFF, GradientCalc::OFF>(
+                [](auto&&... args) {
+                  return internal::wiener5_grad_sv<GradientCalc::ON>(args...);
                 },
                 hcubature_err, params, dim, xmin, xmax,
                 maximal_evaluations_hcubature, absolute_error_hcubature,
@@ -534,24 +544,20 @@ inline auto wiener_full_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
         partials<6>(ops_partials)[i] = 0;
       } else {
         if (st0_value == 0) {
-          derivative = internal::estimate_with_err_check<6, false, 0, true>(
-              [&](auto&&... args) {
-                return internal::wiener7_grad_sw(args...);
-              },
+          derivative = internal::estimate_with_err_check<6, GradientCalc::OFF,
+                                                         0, GradientCalc::ON>(
+              [](auto&&... args) { return internal::wiener7_grad_sw(args...); },
               hcubature_err, y_value - t0_value, a_value, v_value, w_value,
               sv_value, sw_value, log_error_absolute - LOG_TWO);
         } else {
-          derivative
-              = internal::wiener7_integrate<T_partials_return, true, false>(
-                  [&](auto&&... args) {
-                    return internal::wiener7_grad_sw(
-                        args...);
-                  },
-                  hcubature_err, params, 1, xmin, xmax,
-                  maximal_evaluations_hcubature, absolute_error_hcubature,
-                  relative_error_hcubature / 2);
+          derivative = internal::wiener7_integrate<GradientCalc::ON,
+                                                   GradientCalc::OFF>(
+              [](auto&&... args) { return internal::wiener7_grad_sw(args...); },
+              hcubature_err, params, 1, xmin, xmax,
+              maximal_evaluations_hcubature, absolute_error_hcubature,
+              relative_error_hcubature / 2);
         }
-        partials<6>(ops_partials)[i] = derivative / density - 1 / sw_value;
+        partials<6>(ops_partials)[i] = derivative / density - 1.0 / sw_value;
       }
     }
     if (!is_constant_all<T_st0>::value) {
@@ -563,26 +569,25 @@ inline auto wiener_full_lpdf(const T_y& y, const T_a& a, const T_t0& t0,
       } else {
         const T_partials_return t0_st0 = t0_value + st0_value;
         if (sw_value == 0) {
-          f = internal::estimate_with_err_check<5, false, 0, true>(
-              [&](auto&&... args) {
-                return internal::wiener5_density<true>(
-                    args...);
+          f = internal::estimate_with_err_check<5, GradientCalc::OFF, 0,
+                                                GradientCalc::ON>(
+              [](auto&&... args) {
+                return internal::wiener5_density<GradientCalc::ON>(args...);
               },
               log_error_derivative + log(st0_value), y_value - t0_st0, a_value,
               v_value, w_value, sv_value, log_error_absolute - LOG_TWO);
         } else {
           const T_partials_return new_error = log_error_absolute - LOG_TWO;
-          const auto& params_st
+          auto params_st
               = std::make_tuple(y_value, a_value, v_value, w_value, t0_st0,
-                                sv_value, sw_value, 0, new_error);
-          f = internal::wiener7_integrate<T_partials_return, false, false>(
-              [&](auto&&... args) {
-                return internal::wiener5_density<true>(
-                    args...);
+                                sv_value, sw_value, 0.0, new_error);
+          f = internal::wiener7_integrate<GradientCalc::OFF, GradientCalc::OFF>(
+              [](auto&&... args) {
+                return internal::wiener5_density<GradientCalc::ON>(args...);
               },
               hcubature_err, params_st, 1, xmin, xmax,
               maximal_evaluations_hcubature, absolute_error_hcubature,
-              relative_error_hcubature / 2);
+              relative_error_hcubature / 2.0);
         }
         partials<7>(ops_partials)[i] = -1 / st0_value + f / st0_value / density;
       }

--- a/test/unit/math/mix/prob/util.hpp
+++ b/test/unit/math/mix/prob/util.hpp
@@ -1,0 +1,36 @@
+#ifndef STAN_TEST_UNIT_MATH_MIX_PROB_UTIL_HPP
+#define STAN_TEST_UNIT_MATH_MIX_PROB_UTIL_HPP
+
+#include <gtest/gtest.h>
+
+class Wiener7MixArgs : public ::testing::Test {
+ public:
+  const char* function = "function";
+  void SetUp() {}
+
+  Eigen::VectorXd y{{0.1, 0.3}};
+  Eigen::VectorXd a{{2.0, 2.5}};
+  Eigen::VectorXd t0{{0.2, 0.1}};
+  Eigen::VectorXd w{{0.5, 0.2}};
+  Eigen::VectorXd v{{2.0, 0.8}};
+  Eigen::VectorXd sv{{0.2, 0.1}};
+  Eigen::VectorXd sw{{0.1, .99}};
+  Eigen::VectorXd st0{{0.3, .8}};
+
+};
+
+class Wiener5MixArgs : public ::testing::Test {
+ public:
+  const char* function = "function";
+  void SetUp() {}
+
+  Eigen::VectorXd y{{1.0, 0.1, 0.3}};
+  Eigen::VectorXd a{{2.5, 2.0, 2.5}};
+  Eigen::VectorXd t0{{0.2, 0.2, 0.1}};
+  Eigen::VectorXd w{{0.5, 0.5, 0.2}};
+  Eigen::VectorXd v{{2.0, 2.0, 0.8}};
+  Eigen::VectorXd sv{{0.2, 0.2, 0.1}};
+
+};
+
+#endif

--- a/test/unit/math/mix/prob/wiener5_lpdf_0_test.cpp
+++ b/test/unit/math/mix/prob/wiener5_lpdf_0_test.cpp
@@ -1,17 +1,17 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
 
-TEST(mathMixDouble, wiener5_lpdf) {
+TEST(mathMixDouble, wiener_lpdf) {
   double y = 1.0;
   double a = 2.0;
   double t0 = 0.2;
   double w = 0.5;
   double v = 1.5;
   double sv = 0.2;
-  stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+  stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
 }
 
-TEST(mathMixVar, wiener5_lpdf) {
+TEST(mathMixVar, wiener_lpdf) {
   using stan::math::var;
   var y = 1.0;
   var a = 2.0;
@@ -19,10 +19,10 @@ TEST(mathMixVar, wiener5_lpdf) {
   var w = 0.5;
   var v = 1.5;
   var sv = 0.2;
-  stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+  stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
 }
 
-TEST(mathMixFVar, wiener5_lpdf) {
+TEST(mathMixFVar, wiener_lpdf) {
   using stan::math::fvar;
   using stan::math::var;
   fvar<var> y = 1.0;
@@ -32,5 +32,5 @@ TEST(mathMixFVar, wiener5_lpdf) {
   fvar<var> v = 1.5;
   fvar<var> sv = 0.2;
   double error = 1e-4;
-  stan::math::wiener5_lpdf(y, a, t0, w, v, sv, error);
+  stan::math::wiener_lpdf(y, a, t0, w, v, sv, error);
 }

--- a/test/unit/math/mix/prob/wiener5_lpdf_1_test.cpp
+++ b/test/unit/math/mix/prob/wiener5_lpdf_1_test.cpp
@@ -1,87 +1,48 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/mix/prob/util.hpp>
 
-TEST(mathMixScalFun_y_a_t0, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_y_a_t0) {
   auto f_y_a_t0 = [](const auto& w, const auto& v, const auto& sv) {
     return [&w, &v, &sv](const auto& y, const auto& a, const auto& t0) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_y_a_t0(w, v, sv), y, a, t0);
 }
 
-TEST(mathMixScalFun_y_a_w, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_y_a_w) {
   auto f_y_a_w = [](const auto& t0, const auto& v, const auto& sv) {
     return [&t0, &v, &sv](const auto& y, const auto& a, const auto& w) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_y_a_w(t0, v, sv), y, a, w);
 }
 
-TEST(mathMixScalFun_y_a_v, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_y_a_v) {
   auto f_y_a_v = [](const auto& t0, const auto& w, const auto& sv) {
     return [&t0, &w, &sv](const auto& y, const auto& a, const auto& v) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_y_a_v(t0, w, sv), y, a, v);
 }
 
-TEST(mathMixScalFun_y_a_sv, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_y_a_sv) {
   auto f_y_a_sv = [](const auto& t0, const auto& w, const auto& v) {
     return [&t0, &w, &v](const auto& y, const auto& a, const auto& sv) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_y_a_sv(t0, w, v), y, a, sv);
 }
 
-TEST(mathMixScalFun_y_t0_w, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_y_t0_w) {
   auto f_y_t0_w = [](const auto& a, const auto& v, const auto& sv) {
     return [&a, &v, &sv](const auto& y, const auto& t0, const auto& w) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_y_t0_w(a, v, sv), y, t0, w);
 }

--- a/test/unit/math/mix/prob/wiener5_lpdf_2_test.cpp
+++ b/test/unit/math/mix/prob/wiener5_lpdf_2_test.cpp
@@ -1,87 +1,48 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/mix/prob/util.hpp>
 
-TEST(mathMixScalFun_y_t0_v, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_y_t0_v) {
   auto f_y_t0_v = [](const auto& a, const auto& w, const auto& sv) {
     return [&a, &w, &sv](const auto& y, const auto& t0, const auto& v) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_y_t0_v(a, w, sv), y, t0, v);
 }
 
-TEST(mathMixScalFun_y_t0_sv, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_y_t0_sv) {
   auto f_y_t0_sv = [](const auto& a, const auto& w, const auto& v) {
     return [&a, &w, &v](const auto& y, const auto& t0, const auto& sv) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_y_t0_sv(a, w, v), y, t0, sv);
 }
 
-TEST(mathMixScalFun_y_w_v, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_y_w_v) {
   auto f_y_w_v = [](const auto& a, const auto& t0, const auto& sv) {
     return [&a, &t0, &sv](const auto& y, const auto& w, const auto& v) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_y_w_v(a, t0, sv), y, w, v);
 }
 
-TEST(mathMixScalFun_y_w_sv, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_y_w_sv) {
   auto f_y_w_sv = [](const auto& a, const auto& t0, const auto& v) {
     return [&a, &t0, &v](const auto& y, const auto& w, const auto& sv) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_y_w_sv(a, t0, v), y, w, sv);
 }
 
-TEST(mathMixScalFun_y_v_sv, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_y_v_sv) {
   auto f_y_v_sv = [](const auto& a, const auto& t0, const auto& w) {
     return [&a, &t0, &w](const auto& y, const auto& v, const auto& sv) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_y_v_sv(a, t0, w), y, v, sv);
 }

--- a/test/unit/math/mix/prob/wiener5_lpdf_3_test.cpp
+++ b/test/unit/math/mix/prob/wiener5_lpdf_3_test.cpp
@@ -1,87 +1,48 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/mix/prob/util.hpp>
 
-TEST(mathMixScalFun_a_t0_w, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_a_t0_w) {
   auto f_a_t0_w = [](const auto& y, const auto& v, const auto& sv) {
     return [&y, &v, &sv](const auto& a, const auto& t0, const auto& w) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_a_t0_w(y, v, sv), a, t0, w);
 }
 
-TEST(mathMixScalFun_a_t0_v, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_a_t0_v) {
   auto f_a_t0_v = [](const auto& y, const auto& w, const auto& sv) {
     return [&y, &w, &sv](const auto& a, const auto& t0, const auto& v) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_a_t0_v(y, w, sv), a, t0, v);
 }
 
-TEST(mathMixScalFun_a_t0_sv, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_a_t0_sv) {
   auto f_a_t0_sv = [](const auto& y, const auto& w, const auto& v) {
     return [&y, &w, &v](const auto& a, const auto& t0, const auto& sv) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_a_t0_sv(y, w, v), a, t0, sv);
 }
 
-TEST(mathMixScalFun_a_w_v, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_a_w_v) {
   auto f_a_w_v = [](const auto& y, const auto& t0, const auto& sv) {
     return [&y, &t0, &sv](const auto& a, const auto& w, const auto& v) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_a_w_v(y, t0, sv), a, w, v);
 }
 
-TEST(mathMixScalFun_a_w_sv, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_a_w_sv) {
   auto f_a_w_sv = [](const auto& y, const auto& t0, const auto& v) {
     return [&y, &t0, &v](const auto& a, const auto& w, const auto& sv) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_a_w_sv(y, t0, v), a, w, sv);
 }

--- a/test/unit/math/mix/prob/wiener5_lpdf_4_test.cpp
+++ b/test/unit/math/mix/prob/wiener5_lpdf_4_test.cpp
@@ -1,87 +1,48 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/mix/prob/util.hpp>
 
-TEST(mathMixScalFun_a_v_sv, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_a_v_sv) {
   auto f_a_v_sv = [](const auto& y, const auto& t0, const auto& w) {
     return [&y, &t0, &w](const auto& a, const auto& v, const auto& sv) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_a_v_sv(y, t0, w), a, v, sv);
 }
 
-TEST(mathMixScalFun_t0_w_v, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_t0_w_v) {
   auto f_t0_w_v = [](const auto& y, const auto& a, const auto& sv) {
     return [&y, &a, &sv](const auto& t0, const auto& w, const auto& v) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_t0_w_v(y, a, sv), t0, w, v);
 }
 
-TEST(mathMixScalFun_t0_w_sv, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_t0_w_sv) {
   auto f_t0_w_sv = [](const auto& y, const auto& a, const auto& v) {
     return [&y, &a, &v](const auto& t0, const auto& w, const auto& sv) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_t0_w_sv(y, a, v), t0, w, sv);
 }
 
-TEST(mathMixScalFun_t0_v_sv, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_t0_v_sv) {
   auto f_t0_v_sv = [](const auto& y, const auto& a, const auto& w) {
     return [&y, &a, &w](const auto& t0, const auto& v, const auto& sv) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_t0_v_sv(y, a, w), t0, v, sv);
 }
 
-TEST(mathMixScalFun_w_v_sv, wiener5_lpdf) {
+TEST_F(Wiener5MixArgs, wiener_lpdf_w_v_sv) {
   auto f_w_v_sv = [](const auto& y, const auto& a, const auto& t0) {
     return [&y, &a, &t0](const auto& w, const auto& v, const auto& sv) {
-      return stan::math::wiener5_lpdf(y, a, t0, w, v, sv, 1e-4);
+      return stan::math::wiener_lpdf(y, a, t0, w, v, sv, 1e-4);
     };
   };
-
-  double y = 1.0;
-  double a = 2.5;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-
   stan::test::expect_ad(f_w_v_sv(y, a, t0), w, v, sv);
 }

--- a/test/unit/math/mix/prob/wiener_full_lpdf_0_test.cpp
+++ b/test/unit/math/mix/prob/wiener_full_lpdf_0_test.cpp
@@ -1,7 +1,8 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/mix/prob/util.hpp>
 
-TEST(mathMixDouble, wiener_full_lpdf) {
+TEST(mathMixDouble, wiener_lpdf) {
   double y = 1.0;
   double a = 2.0;
   double t0 = 0.2;
@@ -10,10 +11,10 @@ TEST(mathMixDouble, wiener_full_lpdf) {
   double sv = 0.2;
   double sw = 0.2;
   double st0 = 0.2;
-  stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0, 1e-4);
+  stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0, 1e-4);
 }
 
-TEST(mathMixVar, wiener_full_lpdf) {
+TEST(mathMixVar, wiener_lpdf) {
   using stan::math::var;
   var y = 1.0;
   var a = 2.0;
@@ -23,10 +24,10 @@ TEST(mathMixVar, wiener_full_lpdf) {
   var sv = 0.2;
   var sw = 0;
   var st0 = 0.2;
-  stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+  stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
 }
 
-TEST(mathMixFVar, wiener_full_lpdf) {
+TEST(mathMixFVar, wiener_lpdf) {
   using stan::math::fvar;
   using stan::math::var;
   fvar<var> y = 1.0;
@@ -37,26 +38,16 @@ TEST(mathMixFVar, wiener_full_lpdf) {
   fvar<var> sv = 0.2;
   fvar<var> sw = 0;
   fvar<var> st0 = 0.2;
-  stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+  stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
 }
 
-TEST(mathMixScalFun_y_a_t0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_a_t0) {
   auto f_y_a_t0 = [](const auto& w, const auto& v, const auto& sv,
                      const auto& sw, const auto& st0) {
     return
         [&w, &v, &sv, &sw, &st0](const auto& y, const auto& a, const auto& t0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_a_t0(w, v, sv, sw, st0), y, a, t0);
 }

--- a/test/unit/math/mix/prob/wiener_full_lpdf_10_test.cpp
+++ b/test/unit/math/mix/prob/wiener_full_lpdf_10_test.cpp
@@ -1,107 +1,58 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/mix/prob/util.hpp>
 
-TEST(mathMixScalFun_w_v_sv, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_w_v_sv) {
   auto f_w_v_sv = [](const auto& y, const auto& a, const auto& t0,
                      const auto& sw, const auto& st0) {
     return
         [&y, &a, &t0, &sw, &st0](const auto& w, const auto& v, const auto& sv) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_w_v_sv(y, a, t0, sw, st0), w, v, sv);
 }
 
-TEST(mathMixScalFun_w_v_sw, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_w_v_sw) {
   auto f_w_v_sw = [](const auto& y, const auto& a, const auto& t0,
                      const auto& sv, const auto& st0) {
     return
         [&y, &a, &t0, &sv, &st0](const auto& w, const auto& v, const auto& sw) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_w_v_sw(y, a, t0, sv, st0), w, v, sw);
 }
 
-TEST(mathMixScalFun_w_v_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_w_v_st0) {
   auto f_w_v_st0 = [](const auto& y, const auto& a, const auto& t0,
                       const auto& sv, const auto& sw) {
     return
         [&y, &a, &t0, &sv, &sw](const auto& w, const auto& v, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_w_v_st0(y, a, t0, sv, sw), w, v, st0);
 }
 
-TEST(mathMixScalFun_w_sv_sw, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_w_sv_sw) {
   auto f_w_sv_sw = [](const auto& y, const auto& a, const auto& t0,
                       const auto& v, const auto& st0) {
     return
         [&y, &a, &t0, &v, &st0](const auto& w, const auto& sv, const auto& sw) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_w_sv_sw(y, a, t0, v, st0), w, sv, sw);
 }
 
-TEST(mathMixScalFun_w_sv_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_w_sv_st0) {
   auto f_w_sv_st0 = [](const auto& y, const auto& a, const auto& t0,
                        const auto& v, const auto& sw) {
     return
         [&y, &a, &t0, &v, &sw](const auto& w, const auto& sv, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_w_sv_st0(y, a, t0, v, sw), w, sv, st0);
 }

--- a/test/unit/math/mix/prob/wiener_full_lpdf_11_test.cpp
+++ b/test/unit/math/mix/prob/wiener_full_lpdf_11_test.cpp
@@ -1,107 +1,58 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/mix/prob/util.hpp>
 
-TEST(mathMixScalFun_w_sw_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_w_sw_st0) {
   auto f_w_sw_st0 = [](const auto& y, const auto& a, const auto& t0,
                        const auto& v, const auto& sv) {
     return
         [&y, &a, &t0, &v, &sv](const auto& w, const auto& sw, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_w_sw_st0(y, a, t0, v, sv), w, sw, st0);
 }
 
-TEST(mathMixScalFun_v_sv_sw, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_v_sv_sw) {
   auto f_v_sv_sw = [](const auto& y, const auto& a, const auto& t0,
                       const auto& w, const auto& st0) {
     return
         [&y, &a, &t0, &w, &st0](const auto& v, const auto& sv, const auto& sw) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_v_sv_sw(y, a, t0, w, st0), v, sv, sw);
 }
 
-TEST(mathMixScalFun_v_sv_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_v_sv_st0) {
   auto f_v_sv_st0 = [](const auto& y, const auto& a, const auto& t0,
                        const auto& w, const auto& sw) {
     return
         [&y, &a, &t0, &w, &sw](const auto& v, const auto& sv, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_v_sv_st0(y, a, t0, w, sw), v, sv, st0);
 }
 
-TEST(mathMixScalFun_v_sw_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_v_sw_st0) {
   auto f_v_sw_st0 = [](const auto& y, const auto& a, const auto& t0,
                        const auto& w, const auto& sv) {
     return
         [&y, &a, &t0, &w, &sv](const auto& v, const auto& sw, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_v_sw_st0(y, a, t0, w, sv), v, sw, st0);
 }
 
-TEST(mathMixScalFun_sv_sw_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_sv_sw_st0) {
   auto f_sv_sw_st0 = [](const auto& y, const auto& a, const auto& t0,
                         const auto& w, const auto& v) {
     return
         [&y, &a, &t0, &w, &v](const auto& sv, const auto& sw, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_sv_sw_st0(y, a, t0, w, v), sv, sw, st0);
 }

--- a/test/unit/math/mix/prob/wiener_full_lpdf_1_test.cpp
+++ b/test/unit/math/mix/prob/wiener_full_lpdf_1_test.cpp
@@ -1,107 +1,58 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/mix/prob/util.hpp>
 
-TEST(mathMixScalFun_y_a_w, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_a_w) {
   auto f_y_a_w = [](const auto& t0, const auto& v, const auto& sv,
                     const auto& sw, const auto& st0) {
     return
         [&t0, &v, &sv, &sw, &st0](const auto& y, const auto& a, const auto& w) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_a_w(t0, v, sv, sw, st0), y, a, w);
 }
 
-TEST(mathMixScalFun_y_a_v, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_a_v) {
   auto f_y_a_v = [](const auto& t0, const auto& w, const auto& sv,
                     const auto& sw, const auto& st0) {
     return
         [&t0, &w, &sv, &sw, &st0](const auto& y, const auto& a, const auto& v) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_a_v(t0, w, sv, sw, st0), y, a, v);
 }
 
-TEST(mathMixScalFun_y_a_sv, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_a_sv) {
   auto f_y_a_sv = [](const auto& t0, const auto& w, const auto& v,
                      const auto& sw, const auto& st0) {
     return
         [&t0, &w, &v, &sw, &st0](const auto& y, const auto& a, const auto& sv) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_a_sv(t0, w, v, sw, st0), y, a, sv);
 }
 
-TEST(mathMixScalFun_y_a_sw, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_a_sw) {
   auto f_y_a_sw = [](const auto& t0, const auto& w, const auto& v,
                      const auto& sv, const auto& st0) {
     return
         [&t0, &w, &v, &sv, &st0](const auto& y, const auto& a, const auto& sw) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_a_sw(t0, w, v, sv, st0), y, a, sw);
 }
 
-TEST(mathMixScalFun_y_a_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_a_st0) {
   auto f_y_a_st0 = [](const auto& t0, const auto& w, const auto& v,
                       const auto& sv, const auto& sw) {
     return
         [&t0, &w, &v, &sv, &sw](const auto& y, const auto& a, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_a_st0(t0, w, v, sv, sw), y, a, st0);
 }

--- a/test/unit/math/mix/prob/wiener_full_lpdf_2_test.cpp
+++ b/test/unit/math/mix/prob/wiener_full_lpdf_2_test.cpp
@@ -1,107 +1,58 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/mix/prob/util.hpp>
 
-TEST(mathMixScalFun_y_t0_w, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_t0_w) {
   auto f_y_t0_w = [](const auto& a, const auto& v, const auto& sv,
                      const auto& sw, const auto& st0) {
     return
         [&a, &v, &sv, &sw, &st0](const auto& y, const auto& t0, const auto& w) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_t0_w(a, v, sv, sw, st0), y, t0, w);
 }
 
-TEST(mathMixScalFun_y_t0_v, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_t0_v) {
   auto f_y_t0_v = [](const auto& a, const auto& w, const auto& sv,
                      const auto& sw, const auto& st0) {
     return
         [&a, &w, &sv, &sw, &st0](const auto& y, const auto& t0, const auto& v) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_t0_v(a, w, sv, sw, st0), y, t0, v);
 }
 
-TEST(mathMixScalFun_y_t0_sv, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_t0_sv) {
   auto f_y_t0_sv = [](const auto& a, const auto& w, const auto& v,
                       const auto& sw, const auto& st0) {
     return
         [&a, &w, &v, &sw, &st0](const auto& y, const auto& t0, const auto& sv) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_t0_sv(a, w, v, sw, st0), y, t0, sv);
 }
 
-TEST(mathMixScalFun_y_t0_sw, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_t0_sw) {
   auto f_y_t0_sw = [](const auto& a, const auto& w, const auto& v,
                       const auto& sv, const auto& st0) {
     return
         [&a, &w, &v, &sv, &st0](const auto& y, const auto& t0, const auto& sw) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_t0_sw(a, w, v, sv, st0), y, t0, sw);
 }
 
-TEST(mathMixScalFun_y_t0_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_t0_st0) {
   auto f_y_t0_st0 = [](const auto& a, const auto& w, const auto& v,
                        const auto& sv, const auto& sw) {
     return
         [&a, &w, &v, &sv, &sw](const auto& y, const auto& t0, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_t0_st0(a, w, v, sv, sw), y, t0, st0);
 }

--- a/test/unit/math/mix/prob/wiener_full_lpdf_3_test.cpp
+++ b/test/unit/math/mix/prob/wiener_full_lpdf_3_test.cpp
@@ -1,107 +1,58 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/mix/prob/util.hpp>
 
-TEST(mathMixScalFun_y_w_v, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_w_v) {
   auto f_y_w_v = [](const auto& a, const auto& t0, const auto& sv,
                     const auto& sw, const auto& st0) {
     return
         [&a, &t0, &sv, &sw, &st0](const auto& y, const auto& w, const auto& v) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_w_v(a, t0, sv, sw, st0), y, w, v);
 }
 
-TEST(mathMixScalFun_y_w_sv, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_w_sv) {
   auto f_y_w_sv = [](const auto& a, const auto& t0, const auto& v,
                      const auto& sw, const auto& st0) {
     return
         [&a, &t0, &v, &sw, &st0](const auto& y, const auto& w, const auto& sv) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_w_sv(a, t0, v, sw, st0), y, w, sv);
 }
 
-TEST(mathMixScalFun_y_w_sw, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_w_sw) {
   auto f_y_w_sw = [](const auto& a, const auto& t0, const auto& v,
                      const auto& sv, const auto& st0) {
     return
         [&a, &t0, &v, &sv, &st0](const auto& y, const auto& w, const auto& sw) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_w_sw(a, t0, v, sv, st0), y, w, sw);
 }
 
-TEST(mathMixScalFun_y_w_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_w_st0) {
   auto f_y_w_st0 = [](const auto& a, const auto& t0, const auto& v,
                       const auto& sv, const auto& sw) {
     return
         [&a, &t0, &v, &sv, &sw](const auto& y, const auto& w, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_w_st0(a, t0, v, sv, sw), y, w, st0);
 }
 
-TEST(mathMixScalFun_y_v_sv, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_v_sv) {
   auto f_y_v_sv = [](const auto& a, const auto& t0, const auto& w,
                      const auto& sw, const auto& st0) {
     return
         [&a, &t0, &w, &sw, &st0](const auto& y, const auto& v, const auto& sv) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_v_sv(a, t0, w, sw, st0), y, v, sv);
 }

--- a/test/unit/math/mix/prob/wiener_full_lpdf_4_test.cpp
+++ b/test/unit/math/mix/prob/wiener_full_lpdf_4_test.cpp
@@ -1,107 +1,58 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/mix/prob/util.hpp>
 
-TEST(mathMixScalFun_y_v_sw, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_v_sw) {
   auto f_y_v_sw = [](const auto& a, const auto& t0, const auto& w,
                      const auto& sv, const auto& st0) {
     return
         [&a, &t0, &w, &sv, &st0](const auto& y, const auto& v, const auto& sw) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_v_sw(a, t0, w, sv, st0), y, v, sw);
 }
 
-TEST(mathMixScalFun_y_v_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_v_st0) {
   auto f_y_v_st0 = [](const auto& a, const auto& t0, const auto& w,
                       const auto& sv, const auto& sw) {
     return
         [&a, &t0, &w, &sv, &sw](const auto& y, const auto& v, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_v_st0(a, t0, w, sv, sw), y, v, st0);
 }
 
-TEST(mathMixScalFun_y_sv_sw, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_sv_sw) {
   auto f_y_sv_sw = [](const auto& a, const auto& t0, const auto& w,
                       const auto& v, const auto& st0) {
     return
         [&a, &t0, &w, &v, &st0](const auto& y, const auto& sv, const auto& sw) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_sv_sw(a, t0, w, v, st0), y, sv, sw);
 }
 
-TEST(mathMixScalFun_y_sv_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_sv_st0) {
   auto f_y_sv_st0 = [](const auto& a, const auto& t0, const auto& w,
                        const auto& v, const auto& sw) {
     return
         [&a, &t0, &w, &v, &sw](const auto& y, const auto& sv, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_sv_st0(a, t0, w, v, sw), y, sv, st0);
 }
 
-TEST(mathMixScalFun_y_sw_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_y_sw_st0) {
   auto f_y_sw_st0 = [](const auto& a, const auto& t0, const auto& w,
                        const auto& v, const auto& sv) {
     return
         [&a, &t0, &w, &v, &sv](const auto& y, const auto& sw, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_y_sw_st0(a, t0, w, v, sv), y, sw, st0);
 }

--- a/test/unit/math/mix/prob/wiener_full_lpdf_5_test.cpp
+++ b/test/unit/math/mix/prob/wiener_full_lpdf_5_test.cpp
@@ -1,107 +1,58 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/mix/prob/util.hpp>
 
-TEST(mathMixScalFun_a_t0_w, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_a_t0_w) {
   auto f_a_t0_w = [](const auto& y, const auto& v, const auto& sv,
                      const auto& sw, const auto& st0) {
     return
         [&y, &v, &sv, &sw, &st0](const auto& a, const auto& t0, const auto& w) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_a_t0_w(y, v, sv, sw, st0), a, t0, w);
 }
 
-TEST(mathMixScalFun_a_t0_v, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_a_t0_v) {
   auto f_a_t0_v = [](const auto& y, const auto& w, const auto& sv,
                      const auto& sw, const auto& st0) {
     return
         [&y, &w, &sv, &sw, &st0](const auto& a, const auto& t0, const auto& v) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_a_t0_v(y, w, sv, sw, st0), a, t0, v);
 }
 
-TEST(mathMixScalFun_a_t0_sv, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_a_t0_sv) {
   auto f_a_t0_sv = [](const auto& y, const auto& w, const auto& v,
                       const auto& sw, const auto& st0) {
     return
         [&y, &w, &v, &sw, &st0](const auto& a, const auto& t0, const auto& sv) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_a_t0_sv(y, w, v, sw, st0), a, t0, sv);
 }
 
-TEST(mathMixScalFun_a_t0_sw, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_a_t0_sw) {
   auto f_a_t0_sw = [](const auto& y, const auto& w, const auto& v,
                       const auto& sv, const auto& st0) {
     return
         [&y, &w, &v, &sv, &st0](const auto& a, const auto& t0, const auto& sw) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_a_t0_sw(y, w, v, sv, st0), a, t0, sw);
 }
 
-TEST(mathMixScalFun_a_t0_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_a_t0_st0) {
   auto f_a_t0_st0 = [](const auto& y, const auto& w, const auto& v,
                        const auto& sv, const auto& sw) {
     return
         [&y, &w, &v, &sv, &sw](const auto& a, const auto& t0, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_a_t0_st0(y, w, v, sv, sw), a, t0, st0);
 }

--- a/test/unit/math/mix/prob/wiener_full_lpdf_6_test.cpp
+++ b/test/unit/math/mix/prob/wiener_full_lpdf_6_test.cpp
@@ -1,107 +1,58 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/mix/prob/util.hpp>
 
-TEST(mathMixScalFun_a_w_v, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_a_w_v) {
   auto f_a_w_v = [](const auto& y, const auto& t0, const auto& sv,
                     const auto& sw, const auto& st0) {
     return
         [&y, &t0, &sv, &sw, &st0](const auto& a, const auto& w, const auto& v) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_a_w_v(y, t0, sv, sw, st0), a, w, v);
 }
 
-TEST(mathMixScalFun_a_w_sv, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_a_w_sv) {
   auto f_a_w_sv = [](const auto& y, const auto& t0, const auto& v,
                      const auto& sw, const auto& st0) {
     return
         [&y, &t0, &v, &sw, &st0](const auto& a, const auto& w, const auto& sv) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_a_w_sv(y, t0, v, sw, st0), a, w, sv);
 }
 
-TEST(mathMixScalFun_a_w_sw, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_a_w_sw) {
   auto f_a_w_sw = [](const auto& y, const auto& t0, const auto& v,
                      const auto& sv, const auto& st0) {
     return
         [&y, &t0, &v, &sv, &st0](const auto& a, const auto& w, const auto& sw) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_a_w_sw(y, t0, v, sv, st0), a, w, sw);
 }
 
-TEST(mathMixScalFun_a_w_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_a_w_st0) {
   auto f_a_w_st0 = [](const auto& y, const auto& t0, const auto& v,
                       const auto& sv, const auto& sw) {
     return
         [&y, &t0, &v, &sv, &sw](const auto& a, const auto& w, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_a_w_st0(y, t0, v, sv, sw), a, w, st0);
 }
 
-TEST(mathMixScalFun_a_v_sv, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_a_v_sv) {
   auto f_a_v_sv = [](const auto& y, const auto& t0, const auto& w,
                      const auto& sw, const auto& st0) {
     return
         [&y, &t0, &w, &sw, &st0](const auto& a, const auto& v, const auto& sv) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_a_v_sv(y, t0, w, sw, st0), a, v, sv);
 }

--- a/test/unit/math/mix/prob/wiener_full_lpdf_7_test.cpp
+++ b/test/unit/math/mix/prob/wiener_full_lpdf_7_test.cpp
@@ -1,107 +1,58 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/mix/prob/util.hpp>
 
-TEST(mathMixScalFun_a_v_sw, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_a_v_sw) {
   auto f_a_v_sw = [](const auto& y, const auto& t0, const auto& w,
                      const auto& sv, const auto& st0) {
     return
         [&y, &t0, &w, &sv, &st0](const auto& a, const auto& v, const auto& sw) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_a_v_sw(y, t0, w, sv, st0), a, v, sw);
 }
 
-TEST(mathMixScalFun_a_v_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_a_v_st0) {
   auto f_a_v_st0 = [](const auto& y, const auto& t0, const auto& w,
                       const auto& sv, const auto& sw) {
     return
         [&y, &t0, &w, &sv, &sw](const auto& a, const auto& v, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_a_v_st0(y, t0, w, sv, sw), a, v, st0);
 }
 
-TEST(mathMixScalFun_a_sv_sw, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_a_sv_sw) {
   auto f_a_sv_sw = [](const auto& y, const auto& t0, const auto& w,
                       const auto& v, const auto& st0) {
     return
         [&y, &t0, &w, &v, &st0](const auto& a, const auto& sv, const auto& sw) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_a_sv_sw(y, t0, w, v, st0), a, sv, sw);
 }
 
-TEST(mathMixScalFun_a_sv_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_a_sv_st0) {
   auto f_a_sv_st0 = [](const auto& y, const auto& t0, const auto& w,
                        const auto& v, const auto& sw) {
     return
         [&y, &t0, &w, &v, &sw](const auto& a, const auto& sv, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_a_sv_st0(y, t0, w, v, sw), a, sv, st0);
 }
 
-TEST(mathMixScalFun_a_sw_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_a_sw_st0) {
   auto f_a_sw_st0 = [](const auto& y, const auto& t0, const auto& w,
                        const auto& v, const auto& sv) {
     return
         [&y, &t0, &w, &v, &sv](const auto& a, const auto& sw, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_a_sw_st0(y, t0, w, v, sv), a, sw, st0);
 }

--- a/test/unit/math/mix/prob/wiener_full_lpdf_8_test.cpp
+++ b/test/unit/math/mix/prob/wiener_full_lpdf_8_test.cpp
@@ -1,107 +1,58 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/mix/prob/util.hpp>
 
-TEST(mathMixScalFun_t0_w_v, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_t0_w_v) {
   auto f_t0_w_v = [](const auto& y, const auto& a, const auto& sv,
                      const auto& sw, const auto& st0) {
     return
         [&y, &a, &sv, &sw, &st0](const auto& t0, const auto& w, const auto& v) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_t0_w_v(y, a, sv, sw, st0), t0, w, v);
 }
 
-TEST(mathMixScalFun_t0_w_sv, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_t0_w_sv) {
   auto f_t0_w_sv = [](const auto& y, const auto& a, const auto& v,
                       const auto& sw, const auto& st0) {
     return
         [&y, &a, &v, &sw, &st0](const auto& t0, const auto& w, const auto& sv) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_t0_w_sv(y, a, v, sw, st0), t0, w, sv);
 }
 
-TEST(mathMixScalFun_t0_w_sw, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_t0_w_sw) {
   auto f_t0_w_sw = [](const auto& y, const auto& a, const auto& v,
                       const auto& sv, const auto& st0) {
     return
         [&y, &a, &v, &sv, &st0](const auto& t0, const auto& w, const auto& sw) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_t0_w_sw(y, a, v, sv, st0), t0, w, sw);
 }
 
-TEST(mathMixScalFun_t0_w_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_t0_w_st0) {
   auto f_t0_w_st0 = [](const auto& y, const auto& a, const auto& v,
                        const auto& sv, const auto& sw) {
     return
         [&y, &a, &v, &sv, &sw](const auto& t0, const auto& w, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_t0_w_st0(y, a, v, sv, sw), t0, w, st0);
 }
 
-TEST(mathMixScalFun_t0_v_sv, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_t0_v_sv) {
   auto f_t0_v_sv = [](const auto& y, const auto& a, const auto& w,
                       const auto& sw, const auto& st0) {
     return
         [&y, &a, &w, &sw, &st0](const auto& t0, const auto& v, const auto& sv) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_t0_v_sv(y, a, w, sw, st0), t0, v, sv);
 }

--- a/test/unit/math/mix/prob/wiener_full_lpdf_9_test.cpp
+++ b/test/unit/math/mix/prob/wiener_full_lpdf_9_test.cpp
@@ -1,107 +1,58 @@
 #include <stan/math/mix.hpp>
 #include <test/unit/math/test_ad.hpp>
+#include <test/unit/math/mix/prob/util.hpp>
 
-TEST(mathMixScalFun_t0_v_sw, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_t0_v_sw) {
   auto f_t0_v_sw = [](const auto& y, const auto& a, const auto& w,
                       const auto& sv, const auto& st0) {
     return
         [&y, &a, &w, &sv, &st0](const auto& t0, const auto& v, const auto& sw) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_t0_v_sw(y, a, w, sv, st0), t0, v, sw);
 }
 
-TEST(mathMixScalFun_t0_v_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_t0_v_st0) {
   auto f_t0_v_st0 = [](const auto& y, const auto& a, const auto& w,
                        const auto& sv, const auto& sw) {
     return
         [&y, &a, &w, &sv, &sw](const auto& t0, const auto& v, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_t0_v_st0(y, a, w, sv, sw), t0, v, st0);
 }
 
-TEST(mathMixScalFun_t0_sv_sw, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_t0_sv_sw) {
   auto f_t0_sv_sw = [](const auto& y, const auto& a, const auto& w,
                        const auto& v, const auto& st0) {
     return
         [&y, &a, &w, &v, &st0](const auto& t0, const auto& sv, const auto& sw) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_t0_sv_sw(y, a, w, v, st0), t0, sv, sw);
 }
 
-TEST(mathMixScalFun_t0_sv_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_t0_sv_st0) {
   auto f_t0_sv_st0 = [](const auto& y, const auto& a, const auto& w,
                         const auto& v, const auto& sw) {
     return
         [&y, &a, &w, &v, &sw](const auto& t0, const auto& sv, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_t0_sv_st0(y, a, w, v, sw), t0, sv, st0);
 }
 
-TEST(mathMixScalFun_t0_sw_st0, wiener_full_lpdf) {
+TEST_F(Wiener7MixArgs, wiener_lpdf_t0_sw_st0) {
   auto f_t0_sw_st0 = [](const auto& y, const auto& a, const auto& w,
                         const auto& v, const auto& sv) {
     return
         [&y, &a, &w, &v, &sv](const auto& t0, const auto& sw, const auto& st0) {
-          return stan::math::wiener_full_lpdf(y, a, t0, w, v, sv, sw, st0);
+          return stan::math::wiener_lpdf(y, a, t0, w, v, sv, sw, st0);
         };
   };
-
-  double y = 0.1;
-  double a = 2.0;
-  double t0 = 0.2;
-  double w = 0.5;
-  double v = 2.0;
-  double sv = 0.2;
-  double sw = 0.1;
-  double st0 = 0.3;
-
   stan::test::expect_ad(f_t0_sw_st0(y, a, w, v, sv), t0, sw, st0);
 }

--- a/test/unit/math/prim/functor/hcubature_test.cpp
+++ b/test/unit/math/prim/functor/hcubature_test.cpp
@@ -7,58 +7,53 @@
 namespace hcubature_test {
 
 template <typename T_x>
-stan::return_type_t<T_x> f1(const T_x& x) {
+inline auto f1(const T_x& x) {
   return stan::math::sum(stan::math::cos(x));
 }
 
 template <typename T_x>
-stan::return_type_t<T_x> f2(const T_x& x) {
+inline auto f2(const T_x& x) {
   return stan::math::prod(stan::math::cos(x));
 }
 
 template <typename T_x>
-stan::return_type_t<T_x, double> f3(const T_x& x, double radius) {
+inline auto f3(const T_x& x, double radius) {
   using stan::math::square;
-
-  if (stan::math::sum(square(x)) < square(radius)) {
-    return 1;
-  } else {
-    return 0;
-  }
+  return stan::return_type_t<T_x>(stan::math::sum(square(x)) < square(radius));
 }
 
 template <typename T_x>
-stan::return_type_t<T_x, double> f4(const T_x& x, double sigma) {
+inline auto f4(const T_x& x, double sigma) {
   using stan::math::as_array_or_scalar;
   using stan::math::square;
   using stan::math::sum;
   using stan::math::TWO_OVER_SQRT_PI;
 
-  double numerator = sum(square(as_array_or_scalar(x) - 0.5));
+  auto numerator = sum(square(as_array_or_scalar(x) - 0.5));
   return square(TWO_OVER_SQRT_PI / (2.0 * sigma))
          * exp(-numerator / square(sigma));
 }
 
 template <typename T_x>
-stan::return_type_t<T_x> f5(const T_x& x) {
+inline auto f5(const T_x& x) {
   using stan::math::prod;
   using stan::math::square;
   using stan::math::TWO_OVER_SQRT_PI;
 
   const auto& x_arr = stan::math::as_array_or_scalar(x);
-  double val = stan::math::sum(square((1 - x_arr) / x_arr));
-  double scale = prod(TWO_OVER_SQRT_PI / square(x_arr));
+  auto val = stan::math::sum(square((1 - x_arr) / x_arr));
+  auto scale = prod(TWO_OVER_SQRT_PI / square(x_arr));
   return exp(-val) * scale;
 }
 
 template <typename T_x>
-stan::return_type_t<T_x> f6(const T_x& x) {
+inline auto f6(const T_x& x) {
   const auto& x_arr = stan::math::as_array_or_scalar(x);
   return stan::math::prod(2 * x_arr);
 }
 
 template <typename T_x>
-stan::return_type_t<T_x, double> f7(const T_x& x, double a) {
+inline auto f7(const T_x& x, double a) {
   const auto& x_arr = stan::math::as_array_or_scalar(x);
   return stan::math::prod(a / (a + 1)
                           * stan::math::square((a + 1) / (a + x_arr)));
@@ -103,11 +98,11 @@ stan::return_type_t<T_x, double> f7(const T_x& x, double a) {
  * @param val correct value of integral
  */
 
-template <typename F, typename ArgsTupleT>
+template <typename F, typename ArgsTupleT, typename T_a, typename T_b, typename T_relerr>
 void test_integration(const F& f, const ArgsTupleT& pars, int dim,
-                      const Eigen::VectorXd& a, const Eigen::VectorXd& b,
+                      const T_a& a, const T_b& b,
                       int maxEval, double reqAbsError,
-                      const Eigen::VectorXd& reqRelError, double val) {
+                      const T_relerr& reqRelError, double val) {
   using stan::math::hcubature;
 
   for (auto tolerance : reqRelError) {
@@ -125,22 +120,22 @@ TEST(StanMath_hcubature_prim, test1) {
   const Eigen::VectorXd a{{0.0}};
   const Eigen::VectorXd b{{1.0}};
   const Eigen::VectorXd reqRelError{{1e-4, 1e-6, 1e-7}};
-  test_integration(hcubature_test::f1<const Eigen::VectorXd>, std::make_tuple(),
+  test_integration([](auto&& x) { return hcubature_test::f1(x);}, std::make_tuple(),
                    dim, a, b, 6000, 0.0, reqRelError, 0.841471);
 
   dim = 2;
   const Eigen::VectorXd a_2{{0.0, 0.0}};
   const Eigen::VectorXd b_2{{1.0, 1.0}};
-  test_integration(hcubature_test::f2<const Eigen::VectorXd>, std::make_tuple(),
+  test_integration([](auto&& x) { return hcubature_test::f2(x);}, std::make_tuple(),
                    dim, a_2, b_2, 6000, 0.0, reqRelError, 0.7080734);
 
   const Eigen::VectorXd reqRelError_2{{1e-4}};
-  test_integration(hcubature_test::f3<const Eigen::VectorXd>,
+  test_integration([](auto&& x, auto&& radius) { return hcubature_test::f3(x, radius);},
                    std::make_tuple(0.50124145262344534123412), dim, a_2, b_2,
                    10000, 0.0, reqRelError_2, 0.1972807);
 
   // (Gaussian centered at 1/2)
-  test_integration(hcubature_test::f4<const Eigen::VectorXd>,
+  test_integration([](auto&& x, auto&& sigma) { return hcubature_test::f4(x, sigma);},
                    std::make_tuple(0.1), dim, a_2, b_2, 6000, 0.0, reqRelError,
                    1);
 
@@ -148,18 +143,18 @@ TEST(StanMath_hcubature_prim, test1) {
   const Eigen::VectorXd a_3{{0.0, 0.0, 0.0}};
   const Eigen::VectorXd b_3{{1.0, 1.0, 1.0}};
   const Eigen::VectorXd reqRelError_3{{1e-4, 1e-6}};
-  test_integration(hcubature_test::f5<const Eigen::VectorXd>, std::make_tuple(),
+  test_integration([](auto&& x) { return hcubature_test::f5(x);}, std::make_tuple(),
                    dim, a_3, b_3, 6000, 0.0, reqRelError_3, 1.00001);
 
   const Eigen::VectorXd reqRelError_4{{1e-4, 1e-6, 1e-8}};
-  test_integration(hcubature_test::f6<const Eigen::VectorXd>, std::make_tuple(),
+  test_integration([](auto&& x) { return hcubature_test::f6(x);}, std::make_tuple(),
                    dim, a_3, b_3, 6000, 0.0, reqRelError_4, 1);
 
   // (Tsuda's example)
   dim = 4;
   const Eigen::VectorXd a_4{{0.0, 0.0, 0.0, 0.0}};
   const Eigen::VectorXd b_4{{1.0, 1.0, 1.0, 1.0}};
-  test_integration(hcubature_test::f7<const Eigen::VectorXd>,
+  test_integration([](auto&& x, auto&& a) { return hcubature_test::f7(x, a);},
                    std::make_tuple((1 + sqrt(10.0)) / 9.0), dim, a_4, b_4,
                    20000, 0.0, reqRelError_3, 0.999998);
 }


### PR DESCRIPTION
## Summary

1. Removes `Scalar` template parameter from functions and fixes underlying bugs so types can be deduced correctly
2. There were a lot of places the code was doing things like `if (x == 0)`, but the math would be the same in each if with the multiply by 0 parts removed. imo I think the if statement is going to be slower than doing the math so I removed those
3. Pulled up a lot of the if statements out of for loops.
4. Cleaned up a lot of the internal functions

## Tests

The tests now use a test framework `Wiener7MixArgs` and `Wiener5MixArgs` which makes the code a little cleaner.

Once this PR is merged into your branch what I need is for you to go through the two test classes in the util.hpp and for each parameter add values that test their boundaries, extreme values, weird values, etc. to make sure we catch them. So like in the below I modified `w` to check what happens when `w` is 0.99 and 0.01. Note that each vector must be the same size

```
class Wiener5MixArgs : public ::testing::Test {
 public:
  const char* function = "function";
  void SetUp() {}

  Eigen::VectorXd y{{1.0, 0.1, 0.3}};
  Eigen::VectorXd a{{2.5, 2.0, 2.5}};
  Eigen::VectorXd t0{{0.2, 0.2, 0.1}};
  Eigen::VectorXd w{{0.99, 0.5, 0.001}};
  Eigen::VectorXd v{{2.0, 2.0, 0.8}};
  Eigen::VectorXd sv{{0.2, 0.2, 0.1}};

};
```

## Side Effects

Once this is merged we also need to update the docs with all of the new template parameters

## Checklist

- [x] Copyright holder: Steve Bronder

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

- [x] the basic tests are passing

    - unit tests pass (to run, use: `./runTests.py test/unit`)
    - header checks pass, (`make test-headers`)
    - dependencies checks pass, (`make test-math-dependencies`)
    - docs build, (`make doxygen`)
    - code passes the built in [C++ standards](https://github.com/stan-dev/stan/wiki/Coding-Style-and-Idioms) checks (`make cpplint`)

- [x] the code is written in idiomatic C++ and changes are documented in the doxygen

- [x] the new changes are tested
